### PR TITLE
move tensor code to an independent folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: git://github.com/dnephin/pre-commit-golang
+    rev: v0.3.5
+    hooks:
+    - id: go-fmt
+    - id: go-lint
+    - id: validate-toml
+    - id: no-go-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_install:
 
 script:
   - (cd cgotorch; make)
-  - pre-commit -a
+  - pre-commit run -a
   - go run 01-backward.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ language: generic
 os: osx
 compiler: clang
 
+addons:
+  apt:
+    packages:
+      - python3-pip
+
+install:
+  - pip install pre-commit
+
 cache:
   directories:
     # https://pre-commit.com/#travis-ci-example 
@@ -18,6 +26,7 @@ before_install:
   - brew install wget
 
 script:
+  - set -e
   - (cd cgotorch; make)
   - pre-commit -a
   - go run 01-backward.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language: generic
 os: osx
 compiler: clang
 
+cache:
+  directories:
+    # https://pre-commit.com/#travis-ci-example 
+    - $HOME/.cache/pre-commit
 branches:
   only: 
     - master
@@ -15,4 +19,5 @@ before_install:
 
 script:
   - (cd cgotorch; make)
+  - pre-commit -a
   - go run 01-backward.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
   - brew install wget
 
 script:
-  - set -e
   - (cd cgotorch; make)
   - pre-commit -a
   - go run 01-backward.go

--- a/01-backward.go
+++ b/01-backward.go
@@ -1,62 +1,21 @@
 package main
 
-// #cgo CFLAGS: -I ./cgotorch
-// #cgo LDFLAGS: -Wl,-rpath ./cgotorch
-// #cgo LDFLAGS: -L ./cgotorch -lcgotorch -L ./cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
-// #include "cgotorch.h"
-import "C"
-import "fmt"
-
-type Tensor struct {
-	T C.Tensor
-}
-
-func RandN(rows, cols int, require_grad bool) Tensor {
-	rg := 0
-	if require_grad {
-		rg = 1
-	}
-	return Tensor{C.RandN(C.int(rows), C.int(cols), C.int(rg))}
-}
-
-func MM(a, b Tensor) Tensor {
-	return Tensor{C.MM(a.T, b.T)}
-}
-
-func Sum(a Tensor) Tensor {
-	return Tensor{C.Sum(a.T)}
-}
-
-func (a Tensor) String() string {
-	s := C.Tensor_String(a.T)
-	r := C.GoString(s)
-	C.FreeString(s)
-	return r
-}
-
-func (a Tensor) Print() {
-	C.Tensor_Print(a.T)
-}
-
-func (a Tensor) Backward() {
-	C.Tensor_Backward(a.T)
-}
-
-func (a Tensor) Grad() Tensor {
-	return Tensor{C.Tensor_Grad(a.T)}
-}
+import (
+	"fmt"
+	"github.com/wangkuiyi/gotorch/at"
+)
 
 func main() {
-	a := RandN(3, 4, true)
+	a := at.RandN(3, 4, true)
 	fmt.Println(a)
 
-	b := RandN(4, 1, true)
+	b := at.RandN(4, 1, true)
 	fmt.Println(b)
 
-	c := MM(a, b)
+	c := at.MM(a, b)
 	fmt.Println(c)
 
-	d := Sum(c)
+	d := at.Sum(c)
 	fmt.Println(d)
 
 	d.Backward()

--- a/at/tensor.go
+++ b/at/tensor.go
@@ -1,0 +1,54 @@
+package at
+
+// #cgo CFLAGS: -I ${SRCDIR}/../cgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch -Wl,-rpath ${SRCDIR}/../cgotorch -lcgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch/libtorch/lib -Wl,-rpath ${SRCDIR}/../cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
+// #include "cgotorch.h"
+import "C"
+
+// Tensor wrappers a pointer to C.Tensor
+type Tensor struct {
+	T C.Tensor
+}
+
+// RandN returns a tensor filled with random number
+func RandN(rows, cols int, requireGrad bool) Tensor {
+	rg := 0
+	if requireGrad {
+		rg = 1
+	}
+	return Tensor{C.RandN(C.int(rows), C.int(cols), C.int(rg))}
+}
+
+// MM multiplies each element of the input two tensors
+func MM(a, b Tensor) Tensor {
+	return Tensor{C.MM(a.T, b.T)}
+}
+
+// Sum returns the sum of all elements in the input tensor
+func Sum(a Tensor) Tensor {
+	return Tensor{C.Sum(a.T)}
+}
+
+// String returns the Tensor as a string
+func (a Tensor) String() string {
+	s := C.Tensor_String(a.T)
+	r := C.GoString(s)
+	C.FreeString(s)
+	return r
+}
+
+// Print the tensor
+func (a Tensor) Print() {
+	C.Tensor_Print(a.T)
+}
+
+// Backward compute the gradient of current tensor
+func (a Tensor) Backward() {
+	C.Tensor_Backward(a.T)
+}
+
+// Grad returns a reference of the gradient
+func (a Tensor) Grad() Tensor {
+	return Tensor{C.Tensor_Grad(a.T)}
+}

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+  
   typedef void* Tensor;
   Tensor RandN(int rows, int cols, int require_grad);
   Tensor MM(Tensor a, Tensor b);

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
+
   typedef void* Tensor;
   Tensor RandN(int rows, int cols, int require_grad);
   Tensor MM(Tensor a, Tensor b);

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wangkuiyi/gotorch
+
+go 1.13


### PR DESCRIPTION
This PR moved tensor related operators to an independent folder: `at`, the coming examples can reuse these functions.
This PR also added the pre-commit tool to check the Go code.
