### PR TITLE
move GoTorch API into go packages

### DIFF
--- a/01-backward.go
+++ b/01-backward.go
@@ -1,62 +1,22 @@
 package main
 
-// #cgo CFLAGS: -I ./cgotorch
-// #cgo LDFLAGS: -Wl,-rpath ./cgotorch
-// #cgo LDFLAGS: -L ./cgotorch -lcgotorch -L ./cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
-// #include "cgotorch.h"
-import "C"
-import "fmt"
+import (
+	"fmt"
 
-type Tensor struct {
-	T C.Tensor
-}
-
-func RandN(rows, cols int, require_grad bool) Tensor {
-	rg := 0
-	if require_grad {
-		rg = 1
-	}
-	return Tensor{C.RandN(C.int(rows), C.int(cols), C.int(rg))}
-}
-
-func MM(a, b Tensor) Tensor {
-	return Tensor{C.MM(a.T, b.T)}
-}
-
-func Sum(a Tensor) Tensor {
-	return Tensor{C.Sum(a.T)}
-}
-
-func (a Tensor) String() string {
-	s := C.Tensor_String(a.T)
-	r := C.GoString(s)
-	C.FreeString(s)
-	return r
-}
-
-func (a Tensor) Print() {
-	C.Tensor_Print(a.T)
-}
-
-func (a Tensor) Backward() {
-	C.Tensor_Backward(a.T)
-}
-
-func (a Tensor) Grad() Tensor {
-	return Tensor{C.Tensor_Grad(a.T)}
-}
+	"github.com/wangkuiyi/gotorch/at"
+)
 
 func main() {
-	a := RandN(3, 4, true)
+	a := at.RandN(3, 4, true)
 	fmt.Println(a)
 
-	b := RandN(4, 1, true)
+	b := at.RandN(4, 1, true)
 	fmt.Println(b)
 
-	c := MM(a, b)
+	c := at.MM(a, b)
 	fmt.Println(c)
 
-	d := Sum(c)
+	d := at.Sum(c)
 	fmt.Println(d)
 
 	d.Backward()

--- a/01-backward.go
+++ b/01-backward.go
@@ -3,14 +3,15 @@ package main
 import (
 	"fmt"
 
-	"github.com/wangkuiyi/gotorch/at"
+	"github.com/wangkuiyi/gotorch/torch"
+	at "github.com/wangkuiyi/gotorch/aten"
 )
 
 func main() {
-	a := at.RandN(3, 4, true)
+	a := torch.RandN(3, 4, true)
 	fmt.Println(a)
 
-	b := at.RandN(4, 1, true)
+	b := torch.RandN(4, 1, true)
 	fmt.Println(b)
 
 	c := at.MM(a, b)

--- a/at/tensor.go
+++ b/at/tensor.go
@@ -1,0 +1,54 @@
+package at
+
+// #cgo CFLAGS: -I ${SRCDIR}/../cgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch -Wl,-rpath ${SRCDIR}/../cgotorch -lcgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch/libtorch/lib -Wl,-rpath ${SRCDIR}/../cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
+// #include "cgotorch.h"
+import "C"
+
+// Tensor wrappers a pointer to C.Tensor
+type Tensor struct {
+	T C.Tensor
+}
+
+// RandN returns a tensor filled with random number
+func RandN(rows, cols int, requireGrad bool) Tensor {
+	rg := 0
+	if requireGrad {
+		rg = 1
+	}
+	return Tensor{C.RandN(C.int(rows), C.int(cols), C.int(rg))}
+}
+
+// MM multiplies each element of the input two tensors
+func MM(a, b Tensor) Tensor {
+	return Tensor{C.MM(a.T, b.T)}
+}
+
+// Sum returns the sum of all elements in the input tensor
+func Sum(a Tensor) Tensor {
+	return Tensor{C.Sum(a.T)}
+}
+
+// String returns the Tensor as a string
+func (a Tensor) String() string {
+	s := C.Tensor_String(a.T)
+	r := C.GoString(s)
+	C.FreeString(s)
+	return r
+}
+
+// Print the tensor
+func (a Tensor) Print() {
+	C.Tensor_Print(a.T)
+}
+
+// Backward compute the gradient of current tensor
+func (a Tensor) Backward() {
+	C.Tensor_Backward(a.T)
+}
+
+// Grad returns a reference of the gradient
+func (a Tensor) Grad() Tensor {
+	return Tensor{C.Tensor_Grad(a.T)}
+}

--- a/aten/tensor.go
+++ b/aten/tensor.go
@@ -1,35 +1,21 @@
-package at
+package aten
 
 // #cgo CFLAGS: -I ${SRCDIR}/../cgotorch
 // #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch -Wl,-rpath ${SRCDIR}/../cgotorch -lcgotorch
 // #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch/libtorch/lib -Wl,-rpath ${SRCDIR}/../cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
 // #include "cgotorch.h"
 import "C"
+import "unsafe"
 
 // Tensor wrappers a pointer to C.Tensor
 type Tensor struct {
 	T C.Tensor
 }
 
-// RandN returns a tensor filled with random number
-func RandN(rows, cols int, requireGrad bool) Tensor {
-	rg := 0
-	if requireGrad {
-		rg = 1
-	}
-	return Tensor{C.RandN(C.int(rows), C.int(cols), C.int(rg))}
+// NewTensor returns a Tensor
+func NewTensor(t unsafe.Pointer) Tensor {
+	return Tensor{(C.Tensor)(t)}
 }
-
-// MM multiplies each element of the input two tensors
-func MM(a, b Tensor) Tensor {
-	return Tensor{C.MM(a.T, b.T)}
-}
-
-// Sum returns the sum of all elements in the input tensor
-func Sum(a Tensor) Tensor {
-	return Tensor{C.Sum(a.T)}
-}
-
 // String returns the Tensor as a string
 func (a Tensor) String() string {
 	s := C.Tensor_String(a.T)
@@ -51,4 +37,14 @@ func (a Tensor) Backward() {
 // Grad returns a reference of the gradient
 func (a Tensor) Grad() Tensor {
 	return Tensor{C.Tensor_Grad(a.T)}
+}
+
+// MM multiplies each element of the input two tensors
+func MM(a, b Tensor) Tensor {
+	return Tensor{C.MM(a.T, b.T)}
+}
+
+// Sum returns the sum of all elements in the input tensor
+func Sum(a Tensor) Tensor {
+	return Tensor{C.Sum(a.T)}
 }

--- a/aten/tensor.go
+++ b/aten/tensor.go
@@ -16,6 +16,7 @@ type Tensor struct {
 func NewTensor(t unsafe.Pointer) Tensor {
 	return Tensor{(C.Tensor)(t)}
 }
+
 // String returns the Tensor as a string
 func (a Tensor) String() string {
 	s := C.Tensor_String(a.T)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wangkuiyi/gotorch
+
+go 1.13

--- a/torch/torch.go
+++ b/torch/torch.go
@@ -1,0 +1,19 @@
+package torch
+
+// #cgo CFLAGS: -I ${SRCDIR}/../cgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch -Wl,-rpath ${SRCDIR}/../cgotorch -lcgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/../cgotorch/libtorch/lib -Wl,-rpath ${SRCDIR}/../cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
+// #include "cgotorch.h"
+import "C"
+import (
+	"unsafe"
+	"github.com/wangkuiyi/gotorch/aten"
+)
+// RandN returns a tensor filled with random number
+func RandN(rows, cols int, requireGrad bool) aten.Tensor {
+	rg := 0
+	if requireGrad {
+		rg = 1
+	}
+	return aten.NewTensor(unsafe.Pointer(C.RandN(C.int(rows),  C.int(cols), C.int(rg))))
+}

--- a/torch/torch.go
+++ b/torch/torch.go
@@ -6,14 +6,15 @@ package torch
 // #include "cgotorch.h"
 import "C"
 import (
-	"unsafe"
 	"github.com/wangkuiyi/gotorch/aten"
+	"unsafe"
 )
+
 // RandN returns a tensor filled with random number
 func RandN(rows, cols int, requireGrad bool) aten.Tensor {
 	rg := 0
 	if requireGrad {
 		rg = 1
 	}
-	return aten.NewTensor(unsafe.Pointer(C.RandN(C.int(rows),  C.int(cols), C.int(rg))))
+	return aten.NewTensor(unsafe.Pointer(C.RandN(C.int(rows), C.int(cols), C.int(rg))))
 }


### PR DESCRIPTION
This PR moved GoTorch APIs into `aten`, `torch` packages, the coming examples can reuse these functions.
