### PR TITLE
Copy terminating NULL

### DIFF
--- a/cgotorch/cgotorch.cc
+++ b/cgotorch/cgotorch.cc
@@ -40,7 +40,7 @@ const char* Tensor_String(Tensor a) {
   std::stringstream ss;
   ss << *static_cast<at::Tensor*>(a);
   std::string s = ss.str();
-  char* r = new char[s.size()];
+  char* r = new char[s.size() + 1];
   strcpy(r, s.c_str());
   return r;
 }

--- a/cgotorch/cgotorch.cc
+++ b/cgotorch/cgotorch.cc
@@ -41,8 +41,7 @@ const char* Tensor_String(Tensor a) {
   ss << *static_cast<at::Tensor*>(a);
   std::string s = ss.str();
   char* r = new char[s.size() + 1];
-  strcpy(r, s.c_str());
-  return r;
+  return strcpy(r, s.c_str());
 }
 
 void FreeString(const char* s) {


### PR DESCRIPTION
`std::string` doesn't have the terminating NULL. And from the manpage of `strcpy`:
> ```c
> char *
> strcpy(char * dst, const char * src);
> ```
> The strcpy() function copies the string src to dst (including the terminating `\0' character.)
>
> The strcpy() functions returns `dst`.