### PR TITLE
expose SGD optimizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 gotorch
 libcgotorch.so
 *~
+.vscode

--- a/01-backward.go
+++ b/01-backward.go
@@ -8,20 +8,25 @@ import (
 )
 
 func main() {
-	a := torch.RandN(3, 4, true)
-	fmt.Println(a)
-
 	b := torch.RandN(4, 1, true)
+	opt := torch.NewSGDOpt(1, 0, 0, 0, false)
+	opt.AddParameters([]at.Tensor{b})
+
+	fmt.Println("Parameter value:")
 	fmt.Println(b)
 
+	a := torch.RandN(3, 4, false)
 	c := at.MM(a, b)
-	fmt.Println(c)
-
 	d := at.Sum(c)
-	fmt.Println(d)
 
+	opt.ZeroGrad()
 	d.Backward()
 
-	fmt.Println(a.Grad())
+	fmt.Println("Gradient value:")
 	fmt.Println(b.Grad())
+
+	opt.Step()
+
+	fmt.Println("Parameter value after updating:")
+	fmt.Println(b)
 }

--- a/01-backward.go
+++ b/01-backward.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	b := torch.RandN(4, 1, true)
-	opt := torch.NewSGDOpt(1, 0, 0, 0, false)
+	opt := torch.NewSGDOpt(0.1, 0, 0, 0, false)
 	opt.AddParameters([]at.Tensor{b})
 
 	fmt.Println("Parameter value:")

--- a/01-backward.go
+++ b/01-backward.go
@@ -19,12 +19,14 @@ func main() {
 	c := at.MM(a, b)
 	d := at.Sum(c)
 
+	// clear gradients before backward
 	opt.ZeroGrad()
 	d.Backward()
 
 	fmt.Println("Gradient value:")
 	fmt.Println(b.Grad())
 
+	// update parameters
 	opt.Step()
 
 	fmt.Println("Parameter value after updating:")

--- a/cgotorch/cgotorch.cc
+++ b/cgotorch/cgotorch.cc
@@ -1,49 +1,69 @@
+#include "torch/script.h"
+#include "torch/torch.h"
 #include "cgotorch.h"
 
 #include <iostream>
 #include <sstream>
 
-#include "torch/script.h"
+
 
 Tensor RandN(int rows, int cols, int require_grad) {
-  at::Tensor t = torch::randn({rows,cols},
-			      at::TensorOptions().requires_grad(require_grad));
+  at::Tensor t = torch::randn({rows, cols},
+                              at::TensorOptions().requires_grad(require_grad));
   return new at::Tensor(std::move(t));
 }
 
 Tensor MM(Tensor a, Tensor b) {
-  at::Tensor c = at::mm(*static_cast<at::Tensor*>(a),
-			*static_cast<at::Tensor*>(b));
+  at::Tensor c =
+      at::mm(*static_cast<at::Tensor *>(a), *static_cast<at::Tensor *>(b));
   return new at::Tensor(std::move(c));
 }
 
 Tensor Sum(Tensor a) {
-  at::Tensor r = static_cast<at::Tensor*>(a)->sum();
+  at::Tensor r = static_cast<at::Tensor *>(a)->sum();
   return new at::Tensor(std::move(r));
 }
 
-void Tensor_Backward(Tensor a) {
-  static_cast<at::Tensor*>(a)->backward();
-}
+void Tensor_Backward(Tensor a) { static_cast<at::Tensor *>(a)->backward(); }
 
 Tensor Tensor_Grad(Tensor a) {
-  at::Tensor r = static_cast<at::Tensor*>(a)->grad();
+  at::Tensor r = static_cast<at::Tensor *>(a)->grad();
   return new at::Tensor(std::move(r));
 }
 
 void Tensor_Print(Tensor a) {
-  std::cout << *static_cast<at::Tensor*>(a) << std::endl;
+  std::cout << *static_cast<at::Tensor *>(a) << std::endl;
 }
 
 // The caller must free the returned string by calling FreeString.
-const char* Tensor_String(Tensor a) {
+const char *Tensor_String(Tensor a) {
   std::stringstream ss;
-  ss << *static_cast<at::Tensor*>(a);
+  ss << *static_cast<at::Tensor *>(a);
   std::string s = ss.str();
-  char* r = new char[s.size() + 1];
+  char *r = new char[s.size() + 1];
   return strcpy(r, s.c_str());
 }
 
-void FreeString(const char* s) {
-  delete[] s;
+void FreeString(const char *s) { delete[] s; }
+
+Optimizer SGD(double learning_rate, double momentum, double dampening,
+              double weight_decay, int nesterov) {
+  auto options = torch::optim::SGDOptions(learning_rate)
+                     .momentum(momentum)
+                     .dampening(dampening)
+                     .weight_decay(weight_decay)
+                     .nesterov(nesterov);
+  return new torch::optim::SGD(std::vector<torch::Tensor>(), options);
+}
+
+void ZeroGrad(Optimizer opt) {
+  static_cast<torch::optim::SGD *>(opt)->zero_grad();
+}
+
+void Step(Optimizer opt) { static_cast<torch::optim::SGD *>(opt)->step(); }
+
+void AddParameters(Optimizer opt, Tensor *tensors, int length) {
+  for (int i = 0; i < length; ++i)
+    static_cast<torch::optim::SGD *>(opt)->param_groups()[0].params().push_back(
+        *(static_cast<torch::Tensor *>(tensors[i])));
 }

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -5,17 +5,25 @@
 extern "C" {
 #endif
 
-  typedef void* Tensor;
-  Tensor RandN(int rows, int cols, int require_grad);
-  Tensor MM(Tensor a, Tensor b);
-  Tensor Sum(Tensor a);
+typedef void *Tensor;
+typedef void *Optimizer;
+Tensor RandN(int rows, int cols, int require_grad);
+Tensor MM(Tensor a, Tensor b);
+Tensor Sum(Tensor a);
 
-  const char* Tensor_String(Tensor a);
-  void Tensor_Backward(Tensor a);
-  Tensor Tensor_Grad(Tensor a);
-  void Tensor_Print(Tensor a);
+const char *Tensor_String(Tensor a);
+void Tensor_Backward(Tensor a);
+Tensor Tensor_Grad(Tensor a);
+void Tensor_Print(Tensor a);
 
-  void FreeString(const char * s);
+void FreeString(const char *s);
+
+Optimizer SGD(double learning_rate, double momentum, double dampening,
+              double weight_decay, int nesterov);
+
+void ZeroGrad(Optimizer opt);
+void Step(Optimizer opt);
+void AddParameters(Optimizer opt, Tensor *tensors, int length);
 
 #ifdef __cplusplus
 }

--- a/torch/torch.go
+++ b/torch/torch.go
@@ -6,9 +6,16 @@ package torch
 // #include "cgotorch.h"
 import "C"
 import (
-	"github.com/wangkuiyi/gotorch/aten"
+	"reflect"
 	"unsafe"
+
+	"github.com/wangkuiyi/gotorch/aten"
 )
+
+// Optimizer struct
+type Optimizer struct {
+	Opt C.Optimizer
+}
 
 // RandN returns a tensor filled with random number
 func RandN(rows, cols int, requireGrad bool) aten.Tensor {
@@ -17,4 +24,34 @@ func RandN(rows, cols int, requireGrad bool) aten.Tensor {
 		rg = 1
 	}
 	return aten.NewTensor(unsafe.Pointer(C.RandN(C.int(rows), C.int(cols), C.int(rg))))
+}
+
+// NewSGDOpt creates a SGD Optimizer
+func NewSGDOpt(lr, momentum, dampening, weightDecay float64, nesterov bool) Optimizer {
+	nt := 0
+	if nesterov {
+		nt = 1
+	}
+	return Optimizer{C.SGD(C.double(lr), C.double(momentum), C.double(dampening),
+		C.double(weightDecay), C.int(nt))}
+}
+
+// AddParameters adds parameters
+func (opt Optimizer) AddParameters(tensors []aten.Tensor) {
+	CT := []unsafe.Pointer{}
+	for _, t := range tensors {
+		CT = append(CT, unsafe.Pointer(t.T))
+	}
+	p := (*reflect.SliceHeader)(unsafe.Pointer(&CT)).Data
+	C.AddParameters(opt.Opt, (*C.Tensor)(unsafe.Pointer(p)), C.int(len(CT)))
+}
+
+// ZeroGrad reset gradients to zero
+func (opt Optimizer) ZeroGrad() {
+	C.ZeroGrad(opt.Opt)
+}
+
+// Step updates parameters
+func (opt Optimizer) Step() {
+	C.Step(opt.Opt)
 }


### PR DESCRIPTION
This PR exposes the optimizer interface of libtorch to Go.  After run `go run 01-backward.go`, we get the following log:

```
Parameter value:
-0.2994
-0.2610
-1.1278
 0.1280
[ CPUFloatType{4,1} ]
Gradient value:
-1.6246
-1.1954
 0.7638
-0.4145
[ CPUFloatType{4,1} ]
Parameter value after updating:
-0.1369
-0.1414
-1.2042
 0.1695
[ CPUFloatType{4,1} ]
```

The learning rate of SGD optimizer is set to 0.1 . I check the parameter value after updating:  

-0.2994 - 0.1 * (-1.6246) =  -0.1369, 

the result is as expected.

