### PR TITLE
No Go11Module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # According to
 # https://docs.travis-ci.com/user/languages/minimal-and-generic/#generic, the
 # generic language includes Go.
-language: generic
+language: go
 os: osx
 compiler: clang
 
@@ -20,11 +20,11 @@ env:
 
 cache:
   directories:
-    # https://pre-commit.com/#travis-ci-example 
+    # https://pre-commit.com/#travis-ci-example
     - $HOME/.cache/pre-commit
 
 branches:
-  only: 
+  only:
     - master
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ branches:
   only:
     - master
 
-before_install:
-  - brew update
-  - brew install wget
-
 script:
   - bash ./scripts/ci-install.sh
   - (cd cgotorch; make)

--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -1,7 +1,7 @@
 all : libcgotorch.so
 
 libtorch :
-	wget https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.5.1.zip
+	curl -LsO https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.5.1.zip
 	unzip -qq -o libtorch-macos-1.5.1.zip
 
 libcgotorch.so : cgotorch.cc cgotorch.h libtorch

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/wangkuiyi/gotorch
-
-go 1.13

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -2,13 +2,5 @@
 
 set -ex
 
-go env -w GO111MODULE=on
-go get \
-   golang.org/x/lint/golint
-
-echo "$GOPATH"
-echo "$GOROOT"
-
-ls -lt "$GOPATH"/bin
-
-cp "$GOPATH"/bin/* /usr/local/bin/
+go get golang.org/x/lint/golint
+sudo cp "$GOPATH"/bin/* /usr/local/bin/


### PR DESCRIPTION
Our project doesn't specifically require a very recent version of Go. Instead, 1.11.x works well.  So I removed the go.mod with its content `go: 1.13`.

Also, the Travis CI osx VM image contains curl. So, I change the use of wget into curl, and we don't need to install wget in .travis.yml.