### PR TITLE
add go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # https://docs.travis-ci.com/user/languages/minimal-and-generic/#generic, the
 # generic language includes Go.
 language: go
+go:
+  - 1.13
 os: osx
 compiler: clang
 
@@ -19,7 +21,6 @@ env:
   global:
   - GOPATH=$HOME/go
   - PATH=$GOPATH/bin:$PATH
-  - GO111MODULE=on
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   global:
   - GOPATH=$HOME/go
   - PATH=$GOPATH/bin:$PATH
+  - GO111MODULE=on
 
 cache:
   directories:
@@ -31,3 +32,4 @@ branches:
 
 script:
   - pre-commit run -a && (cd cgotorch; make) && go install ./...
+  - $GOPATH/bin/backward

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/wangkuiyi/gotorch
 
-go 1.11
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wangkuiyi/gotorch
+
+go 1.11


### PR DESCRIPTION
Go module is the new packages dependencies management system of Go. Without using the Go module tool, we have to copy the source code to `$GOPATH/src/github.com/wangkuiyi/gotorch` directory, which is not convenient.

This PR adds a go.mod file with go version 1.13, we could run it with go version 1.13+.

The go version in Travis is also set to 1.13.