### PR TITLE
Use sync.WaitGroup to make sure all finalizers are done

### DIFF
--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -9,6 +9,7 @@ func main() {
 	opt := torch.NewSGDOpt(0.1, 0, 0, 0, false)
 	opt.AddParameters([]torch.Tensor{a})
 
+	torch.PrepareGC()
 	for i := 0; i < 100; i++ {
 		torch.GC()
 		b := torch.RandN(10, 100, false)
@@ -19,4 +20,5 @@ func main() {
 		loss.Backward()
 		opt.Step()
 	}
+	torch.FinishGC()
 }

--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -9,7 +9,6 @@ func main() {
 	opt := torch.NewSGDOpt(0.1, 0, 0, 0, false)
 	opt.AddParameters([]torch.Tensor{a})
 
-	torch.PrepareGC()
 	for i := 0; i < 100; i++ {
 		torch.GC()
 		b := torch.RandN(10, 100, false)

--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -10,6 +10,7 @@ func main() {
 	opt.AddParameters([]torch.Tensor{a})
 
 	for i := 0; i < 100; i++ {
+		torch.GC()
 		b := torch.RandN(10, 100, false)
 		pre := torch.MM(b, a)
 		loss := torch.Sum(pre)
@@ -17,12 +18,5 @@ func main() {
 		opt.ZeroGrad()
 		loss.Backward()
 		opt.Step()
-
-		loss.Close()
-		pre.Close()
-		b.Close()
 	}
-
-	opt.Close()
-	a.Close()
 }

--- a/tensor.go
+++ b/tensor.go
@@ -79,14 +79,14 @@ func (a Tensor) Grad() Tensor {
 
 // MM multiplies each element of the input two tensors
 func MM(a, b Tensor) Tensor {
-	t := C.MM(a.T, b.T)
+	t := C.MM(*a.T, *b.T)
 	setTensorFinalizer(&t)
 	return Tensor{&t}
 }
 
 // Sum returns the sum of all elements in the input tensor
 func Sum(a Tensor) Tensor {
-	t := C.Sum(a.T)
+	t := C.Sum(*a.T)
 	setTensorFinalizer(&t)
 	return Tensor{&t}
 }

--- a/torch.go
+++ b/torch.go
@@ -13,7 +13,7 @@ import (
 
 // Optimizer struct
 type Optimizer struct {
-	Opt C.Optimizer
+	Opt *C.Optimizer
 }
 
 // RandN returns a tensor filled with random number
@@ -46,20 +46,20 @@ func (opt Optimizer) AddParameters(tensors []Tensor) {
 		CT = append(CT, unsafe.Pointer(t.T))
 	}
 	p := (*reflect.SliceHeader)(unsafe.Pointer(&CT)).Data
-	C.AddParameters(opt.Opt, (*C.Tensor)(unsafe.Pointer(p)), C.int(len(CT)))
+	C.AddParameters(*opt.Opt, (*C.Tensor)(unsafe.Pointer(p)), C.int(len(CT)))
 }
 
 // ZeroGrad reset gradients to zero
 func (opt Optimizer) ZeroGrad() {
-	C.ZeroGrad(opt.Opt)
+	C.ZeroGrad(*opt.Opt)
 }
 
 // Step updates parameters
 func (opt Optimizer) Step() {
-	C.Step(opt.Opt)
+	C.Step(*opt.Opt)
 }
 
 // Close the optimizer
 func (opt Optimizer) Close() {
-	C.Optimizer_Close(opt.Opt)
+	C.Optimizer_Close(*opt.Opt)
 }

--- a/torch.go
+++ b/torch.go
@@ -43,7 +43,7 @@ func NewSGDOpt(lr, momentum, dampening, weightDecay float64, nesterov bool) Opti
 func (opt Optimizer) AddParameters(tensors []Tensor) {
 	CT := []unsafe.Pointer{}
 	for _, t := range tensors {
-		CT = append(CT, unsafe.Pointer(t.T))
+		CT = append(CT, unsafe.Pointer(*t.T))
 	}
 	p := (*reflect.SliceHeader)(unsafe.Pointer(&CT)).Data
 	C.AddParameters(*opt.Opt, (*C.Tensor)(unsafe.Pointer(p)), C.int(len(CT)))


### PR DESCRIPTION
This is a stricter version of https://github.com/wangkuiyi/gotorch/pull/36
Because `optimizer`s have a different lifetime with `tensor`s, they are not recycled by `torch.GC()`