### PR TITLE
Remove unnecessary std::move

### DIFF
--- a/cgotorch/cgotorch.cc
+++ b/cgotorch/cgotorch.cc
@@ -1,5 +1,7 @@
 #include "torch/script.h"
 #include "torch/torch.h"
+
+// FIXME(shendiaomo): including cgotorch.h before torch/torch.h will fail
 #include "cgotorch.h"
 
 #include <iostream>
@@ -98,9 +100,9 @@ using TypeDataLoader = torch::data::StatelessDataLoader<torch::data::datasets::M
 using TypeIterator = torch::data::Iterator<TypeDataLoader::BatchType>;
 
 DataLoader MakeDataLoader(Dataset dataset, int batchsize) {
-  auto p = torch::data::make_data_loader<torch::data::samplers::SequentialSampler>(
-          std::move(*(static_cast<torch::data::datasets::MNIST *>(dataset))), batchsize);
-  return std::move(p.release());
+  auto p = torch::data::make_data_loader(
+          *(static_cast<torch::data::datasets::MNIST *>(dataset)), batchsize);
+  return p.release();
 }
 
 Iterator Loader_Begin(DataLoader loader) {
@@ -109,8 +111,8 @@ Iterator Loader_Begin(DataLoader loader) {
 
 Data Loader_Data(Iterator iter) {
   Data data;
-  data.Data = new at::Tensor(std::move(*static_cast<TypeIterator *>(iter))->data()->data);
-  data.Target = new at::Tensor(std::move(*static_cast<TypeIterator *>(iter))->data()->target);
+  data.Data = new at::Tensor((*static_cast<TypeIterator *>(iter))->data()->data);
+  data.Target = new at::Tensor((*static_cast<TypeIterator *>(iter))->data()->target);
   return data;
 }
 

--- a/cgotorch/cgotorch.cc
+++ b/cgotorch/cgotorch.cc
@@ -8,25 +8,25 @@
 Tensor RandN(int rows, int cols, int require_grad) {
   at::Tensor t = torch::randn({rows, cols},
                               at::TensorOptions().requires_grad(require_grad));
-  return new at::Tensor(std::move(t));
+  return new at::Tensor(t);
 }
 
 Tensor MM(Tensor a, Tensor b) {
   at::Tensor c =
       at::mm(*static_cast<at::Tensor *>(a), *static_cast<at::Tensor *>(b));
-  return new at::Tensor(std::move(c));
+  return new at::Tensor(c);
 }
 
 Tensor Sum(Tensor a) {
   at::Tensor r = static_cast<at::Tensor *>(a)->sum();
-  return new at::Tensor(std::move(r));
+  return new at::Tensor(r);
 }
 
 void Tensor_Backward(Tensor a) { static_cast<at::Tensor *>(a)->backward(); }
 
 Tensor Tensor_Grad(Tensor a) {
   at::Tensor r = static_cast<at::Tensor *>(a)->grad();
-  return new at::Tensor(std::move(r));
+  return new at::Tensor(r);
 }
 
 void Tensor_Print(Tensor a) {


### PR DESCRIPTION
The copy constructor is adequate for this scenario.