### PR TITLE
add Linear Module

### DIFF
--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -4,7 +4,6 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 )
 
-// MyNet struct
 type myNet struct {
 	torch.Model
 	l1, l2 torch.Module

--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -4,15 +4,39 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 )
 
+// MyNet struct
+type myNet struct {
+	torch.Model
+	l1, l2 torch.Module
+}
+
+// MyNet returns a MyNet instance
+func MyNet() torch.Module {
+	n := &myNet{
+		l1: torch.Linear(100, 200, false),
+		l2: torch.Linear(200, 10, false),
+	}
+	n.RegisterModule("l1", n.l1)
+	n.RegisterModule("l2", n.l2)
+	return n
+}
+
+// Forward executes the calculation
+func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
+	x = n.l1.Forward(x)
+	x = n.l2.Forward(x)
+	return x
+}
+
 func main() {
-	a := torch.RandN(100, 10, true)
+	net := MyNet()
 	opt := torch.NewSGDOpt(0.1, 0, 0, 0, false)
-	opt.AddParameters([]torch.Tensor{a})
+	opt.AddParameters(torch.GetParameters(net))
 
 	for i := 0; i < 100; i++ {
 		torch.GC()
-		b := torch.RandN(10, 100, false)
-		pre := torch.MM(b, a)
+		data := torch.RandN(32, 100, false)
+		pre := net.Forward(data)
 		loss := torch.Sum(pre)
 
 		opt.ZeroGrad()

--- a/examples/sgd/sgd.go
+++ b/examples/sgd/sgd.go
@@ -44,4 +44,6 @@ func main() {
 		opt.Step()
 	}
 	torch.FinishGC()
+	opt.Close()
+	torch.CloseModule(net)
 }

--- a/tensor.go
+++ b/tensor.go
@@ -64,6 +64,11 @@ func (a Tensor) Print() {
 	C.Tensor_Print(*a.T)
 }
 
+// Close the tensor
+func (a Tensor) Close() {
+	C.Tensor_Close(*a.T)
+}
+
 // Backward compute the gradient of current tensor
 func (a Tensor) Backward() {
 	C.Tensor_Backward(*a.T)

--- a/torch.go
+++ b/torch.go
@@ -63,3 +63,108 @@ func (opt Optimizer) Step() {
 func (opt Optimizer) Close() {
 	C.Optimizer_Close(*opt.Opt)
 }
+
+// Module interface
+type Module interface {
+	Forward(x Tensor) Tensor
+}
+
+// Model struct
+type Model struct {
+	parameters map[string]Tensor
+	buffers    map[string]Tensor
+	modules    map[string]Module
+}
+
+// RegisterBuffer registers a buffer to the model
+func (m *Model) RegisterBuffer(s string, t Tensor) {
+	if m.buffers == nil {
+		m.buffers = make(map[string]Tensor)
+	}
+	m.buffers[s] = t
+}
+
+// RegisterParameter registers a parameter to the model
+func (m *Model) RegisterParameter(s string, p Tensor) {
+	if m.parameters == nil {
+		m.parameters = make(map[string]Tensor)
+	}
+	m.parameters[s] = p
+}
+
+// RegisterModule registers a module to the model
+func (m *Model) RegisterModule(s string, module Module) {
+	if m.modules == nil {
+		m.modules = make(map[string]Module)
+	}
+	m.modules[s] = module
+}
+
+type linear struct {
+	Model
+	InFeatures  int
+	OutFeatures int
+	Weight      Tensor
+	Bias        Tensor
+}
+
+// Linear creates a linear instance
+func Linear(in int, out int, bias bool) Module {
+	l := &linear{
+		InFeatures:  in,
+		OutFeatures: out,
+	}
+	l.Weight = RandN(in, out, true)
+	l.RegisterParameter("Weight", l.Weight)
+	if bias {
+		l.Bias = RandN(out, 1, true)
+		l.RegisterParameter("Bias", l.Bias)
+	}
+	return l
+}
+
+// Forward method
+func (l *linear) Forward(x Tensor) Tensor {
+	return MM(x, l.Weight)
+}
+
+// GetChildrenModules returns children modules recursively
+func GetChildrenModules(m Module) map[string]Module {
+	result := make(map[string]Module)
+	model := reflect.ValueOf(m).Elem().Field(0).Interface().(Model)
+	for name, cm := range model.modules {
+		result[name] = cm
+		res := GetChildrenModules(cm)
+		for k, v := range res {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// GetNamedParameters returns named parameters
+func GetNamedParameters(m Module) map[string]Tensor {
+	result := make(map[string]Tensor)
+	model := reflect.ValueOf(m).Elem().Field(0).Interface().(Model)
+	for k, v := range model.parameters {
+		result[k] = v
+	}
+	for moduleName, v := range GetChildrenModules(m) {
+		cmodel := reflect.ValueOf(v).Elem().Field(0).Interface().(Model)
+		for paramName, cv := range cmodel.parameters {
+			name := moduleName + "_" + paramName
+			result[name] = cv
+		}
+	}
+	return result
+}
+
+// GetParameters returns parameters
+func GetParameters(m Module) []Tensor {
+	result := make([]Tensor, 0)
+	n := GetNamedParameters(m)
+	for _, v := range n {
+		result = append(result, v)
+	}
+	return result
+}

--- a/torch.go
+++ b/torch.go
@@ -168,3 +168,11 @@ func GetParameters(m Module) []Tensor {
 	}
 	return result
 }
+
+// CloseModule closes the module
+func CloseModule(m Module) {
+	params := GetParameters(m)
+	for _, p := range params {
+		p.Close()
+	}
+}


### PR DESCRIPTION
A feed forward neural network example:

```go
type myNet struct {
	torch.Model
	l1, l2 torch.Module
}

// MyNet returns a MyNet instance
func MyNet() torch.Module {
	n := &myNet{
		l1: torch.Linear(100, 200, false),
		l2: torch.Linear(200, 10, false),
	}
	n.RegisterModule("l1", n.l1)
	n.RegisterModule("l2", n.l2)
	return n
}

// Forward executes the calculation
func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
	x = n.l1.Forward(x)
	x = n.l2.Forward(x)
	return x
}

func main() {
	net := MyNet()
	opt := torch.NewSGDOpt(0.1, 0, 0, 0, false)
	opt.AddParameters(torch.GetParameters(net))

	for i := 0; i < 100; i++ {
		torch.GC()
		data := torch.RandN(32, 100, false)
		pre := net.Forward(data)
		loss := torch.Sum(pre)

		opt.ZeroGrad()
		loss.Backward()
		opt.Step()
	}
	torch.FinishGC()
	opt.Close()
	torch.CloseModule(net)
}
```