### PR TITLE
Fix synchronizing bug

### DIFF
--- a/tensor.go
+++ b/tensor.go
@@ -17,13 +17,14 @@ var (
 )
 
 func setTensorFinalizer(t *C.Tensor) {
-	if gcPrepared {
+	p := gcPrepared
+	if p {
 		tensorFinalizersWG.Add(1)
 	}
 	runtime.SetFinalizer(t, func(t *C.Tensor) {
 		go func() {
 			C.Tensor_Close(*t)
-			if gcPrepared {
+			if p {
 				tensorFinalizersWG.Done()
 			}
 		}()

--- a/tensor.go
+++ b/tensor.go
@@ -17,7 +17,7 @@ var (
 )
 
 func setTensorFinalizer(t *C.Tensor) {
-	// We don't want the following conditional and the finalizer using 
+	// We don't want the following conditional and the finalizer using
 	// different gcPrepared values, so we leverage p and closure here.
 	p := gcPrepared
 	if p {

--- a/tensor.go
+++ b/tensor.go
@@ -17,6 +17,8 @@ var (
 )
 
 func setTensorFinalizer(t *C.Tensor) {
+	// We don't want the following conditional and the finalizer using 
+	// different gcPrepared values, so we leverage p and closure here.
 	p := gcPrepared
 	if p {
 		tensorFinalizersWG.Add(1)


### PR DESCRIPTION
Fix #44 
The original code may have different `gcPrepared ` in `setTensorFinalizer ` and the anonymouse goroutine. This PR leverages closure to fix the problem.