### PR TITLE
Enable building the Linux version in a Docker container

### DIFF
--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -1,10 +1,14 @@
 all : libcgotorch.so
 
-libtorch :
+libtorch-macos-1.5.1.zip :
 	curl -LsO https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.5.1.zip
-	unzip -qq -o libtorch-macos-1.5.1.zip
 
-libcgotorch.so : cgotorch.cc cgotorch.h libtorch
+macos/libtorch : libtorch-macos-1.5.1.zip
+	unzip -qq -o $< -d macos
+
+libcgotorch.so : cgotorch.cc cgotorch.h macos/libtorch
+	rm -f libtorch
+	ln -s macos/libtorch libtorch
 	clang++ -std=c++14 \
 	-I .. \
 	-I libtorch/include \
@@ -12,13 +16,11 @@ libcgotorch.so : cgotorch.cc cgotorch.h libtorch
 	-L libtorch/lib \
 	-fPIC \
 	-shared \
-	$< \
+	cgotorch.cc \
 	-o $@ -install_name @rpath/$@ \
 	-Wl,-rpath,libtorch/lib \
 	-Wl,-all_load libtorch/lib/libc10.dylib \
-	libtorch/lib/libc10.dylib \
-	libtorch/lib/libtorch.dylib \
-	libtorch/lib/libtorch_cpu.dylib
+	-lc10 -ltorch -ltorch_cpu
 
 clean:
 	rm -rf *.so

--- a/cgotorch/Makefile.linux
+++ b/cgotorch/Makefile.linux
@@ -1,0 +1,26 @@
+all : libcgotorch.so
+
+libtorch-shared-with-deps-1.5.1%2Bcpu.zip :
+	curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.5.1%2Bcpu.zip'
+
+linux/libtorch : libtorch-shared-with-deps-1.5.1%2Bcpu.zip
+	unzip -qq -o $< -d linux
+
+libcgotorch.so : cgotorch.cc cgotorch.h linux/libtorch
+	rm -f libtorch
+	ln -s linux/libtorch libtorch
+	clang++ -std=c++14 \
+	-I .. \
+	-I libtorch/include \
+	-I libtorch/include/torch/csrc/api/include \
+	-L libtorch/lib \
+	-fPIC \
+	-shared \
+	cgotorch.cc \
+	-o $@ -install_name @rpath/$@ \
+	-Wl,-rpath,libtorch/lib \
+	-Wl,-force_load libtorch/lib/libc10.so \
+	-lc10 -ltorch -ltorch_cpu
+
+clean:
+	rm -rf *.so

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:bionic
+
+RUN apt-get -qq update && apt-get -qq install -y curl unzip make git clang clang-format cppcheck python3-pip
+RUN python3 -m pip install -qq pre-commit cpplint
+RUN curl -Ls https://golang.org/dl/go1.14.6.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN GOPATH=/go /usr/local/go/bin/go get golang.org/x/lint/golint
+RUN GOPATH=/go /usr/local/go/bin/go get github.com/stretchr/testify
+RUN cp /go/bin/* /usr/local/bin/
+
+RUN echo 'export GOPATH=/go' >> /root/.bashrc
+RUN echo 'export PATH=/usr/local/go/bin:/go/bin:$PATH' >> /root/.bashrc


### PR DESCRIPTION
## On macOS

```bash
cd cgotorch
make clean
make
cd ..
go test -v
```

## In Docker Container

To build the image and run the container:

```bash
docker build -t dev docker
docker run --rm -it -v $GOPATH:/go -w /go/src/github.com/wangkuiyi/gotorch dev
```

and in the container, type the commands as for macOS, except for the make command -- we need to use Makefile.linux instead of Maekfile.

```bash
make -f Makefile.linux
```