### PR TITLE
Define the  Module interface and the `Sequential` and `Functional` containers

### DIFF
--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -1,11 +1,12 @@
 // Copyright 2020, GoTorch Authors
+#include "torch/torch.h"
+
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "torch/script.h"
-#include "torch/torch.h"
 
 // FIXME(shendiaomo): including cgotorch.h before torch/torch.h will fail
 #include "cgotorch/cgotorch.h"

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -10,14 +10,15 @@ import (
 )
 
 type MLPMNISTNet struct {
-	FC1, FC2, FC3 nn.Module
+	nn.Module
+	FC1, FC2, FC3 *nn.Linear
 }
 
-func NewMNISTNet() nn.Module {
+func NewMNISTNet() *MLPMNISTNet {
 	return &MLPMNISTNet{
-		FC1: nn.Linear(28*28, 512, false),
-		FC2: nn.Linear(512, 512, false),
-		FC3: nn.Linear(512, 10, false),
+		FC1: nn.NewLinear(28*28, 512, false),
+		FC2: nn.NewLinear(512, 512, false),
+		FC3: nn.NewLinear(512, 10, false),
 	}
 }
 
@@ -59,6 +60,51 @@ func ExampleTrainMNIST() {
 	throughput := float64(60000*epochs) / time.Since(startTime).Seconds()
 	log.Printf("Throughput: %f samples/sec", throughput)
 
+	mnist.Close()
+	torch.FinishGC()
+	// Output:
+}
+
+type MLPMNISTSequential struct {
+	nn.Module
+	Layers *nn.Sequential
+}
+
+func (s *MLPMNISTSequential) Forward(x torch.Tensor) torch.Tensor {
+	x = torch.View(x, []int64{-1, 28 * 28})
+	return s.Layers.Forward(x).(torch.Tensor).LogSoftmax(1)
+}
+
+func ExampleTrainMNISTSequential() {
+	if e := downloadMNIST(); e != nil {
+		log.Printf("Cannot find or download MNIST dataset: %v", e)
+	}
+	net := &MLPMNISTSequential{Layers: nn.NewSequential(
+		nn.NewLinear(28*28, 512, false),
+		nn.NewFunctional(torch.Tanh),
+		nn.NewLinear(512, 512, false),
+		nn.NewFunctional(torch.Tanh),
+		nn.NewLinear(512, 10, false))}
+	transforms := []torch.Transform{torch.NewNormalize(0.1307, 0.3081)}
+	mnist := torch.NewMNIST(dataDir(), transforms)
+	opt := torch.SGD(0.1, 0.5, 0, 0, false)
+	opt.AddParameters(nn.GetParameters(net))
+	epochs := 4
+	startTime := time.Now()
+	for i := 0; i < epochs; i++ {
+		trainLoader := torch.NewDataLoader(mnist, 64)
+		for trainLoader.Scan() {
+			batch := trainLoader.Batch()
+			opt.ZeroGrad()
+			pred := net.Forward(batch.Data)
+			loss := F.NllLoss(pred, batch.Target, torch.Tensor{}, -100, "mean")
+			loss.Backward()
+			opt.Step()
+		}
+		trainLoader.Close()
+	}
+	throughput := float64(60000*epochs) / time.Since(startTime).Seconds()
+	log.Printf("Throughput: %f samples/sec", throughput)
 	mnist.Close()
 	torch.FinishGC()
 	// Output:

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -15,11 +15,12 @@ type MLPMNISTNet struct {
 }
 
 func NewMNISTNet() *MLPMNISTNet {
-	return &MLPMNISTNet{
+	r := &MLPMNISTNet{
 		FC1: nn.NewLinear(28*28, 512, false),
 		FC2: nn.NewLinear(512, 512, false),
-		FC3: nn.NewLinear(512, 10, false),
-	}
+		FC3: nn.NewLinear(512, 10, false)}
+	r.Init(r)
+	return r
 }
 
 func (n *MLPMNISTNet) Forward(x torch.Tensor) torch.Tensor {
@@ -40,8 +41,9 @@ func ExampleTrainMNIST() {
 	mnist := torch.NewMNIST(dataDir(), transforms)
 
 	net := NewMNISTNet()
+	net.ZeroGrad()
 	opt := torch.SGD(0.01, 0.5, 0, 0, false)
-	opt.AddParameters(nn.GetParameters(net))
+	opt.AddParameters(net.Parameters())
 
 	epochs := 5
 	startTime := time.Now()
@@ -85,10 +87,12 @@ func ExampleTrainMNISTSequential() {
 		nn.NewLinear(512, 512, false),
 		nn.NewFunctional(torch.Tanh),
 		nn.NewLinear(512, 10, false))}
+	net.Init(net)
+	net.ZeroGrad()
 	transforms := []torch.Transform{torch.NewNormalize(0.1307, 0.3081)}
 	mnist := torch.NewMNIST(dataDir(), transforms)
 	opt := torch.SGD(0.1, 0.5, 0, 0, false)
-	opt.AddParameters(nn.GetParameters(net))
+	opt.AddParameters(net.Parameters())
 	epochs := 4
 	startTime := time.Now()
 	for i := 0; i < epochs; i++ {

--- a/nn/container.go
+++ b/nn/container.go
@@ -1,0 +1,64 @@
+package nn
+
+import (
+	torch "github.com/wangkuiyi/gotorch"
+	"reflect"
+)
+
+// Sequential is a list of `Module`s that acts as a `Module` itself.
+type Sequential struct {
+	Module
+	Modules []IModule
+}
+
+// NewSequential returns a new `Sequential` instance.
+func NewSequential(modules ...IModule) *Sequential {
+	return &Sequential{Module: Module{isTraining: true}, Modules: modules}
+}
+
+// Forward feeds `inputs` to the first module and then chains outputs to inputs, returning the last output.
+func (s *Sequential) Forward(inputs ...interface{}) interface{} {
+	if len(s.Modules) == 0 {
+		panic("Cannot call forward() on an empty Sequential")
+	}
+	forward := reflect.ValueOf(s.Modules[0]).MethodByName("Forward")
+	input := getInterfaceInputs(forward.Call(getReflectInputs(inputs)))
+	for i := 1; i < len(s.Modules); i++ {
+		forward := reflect.ValueOf(s.Modules[i]).MethodByName("Forward")
+		input = getInterfaceInputs(forward.Call(getReflectInputs(input)))
+	}
+	if len(input) != 1 {
+		panic("The last module in Sequential must have exactly one return value")
+	}
+	return input[0]
+}
+
+func getReflectInputs(inputs []interface{}) (r []reflect.Value) {
+	for _, i := range inputs {
+		r = append(r, reflect.ValueOf(i))
+	}
+	return r
+}
+
+func getInterfaceInputs(prevReturned []reflect.Value) (r []interface{}) {
+	for _, v := range prevReturned {
+		r = append(r, v.Interface())
+	}
+	return r
+}
+
+// Functional wraps a function in a `Module`.
+type Functional struct {
+	Module
+	function func(torch.Tensor) torch.Tensor
+}
+
+// NewFunctional returns a new `Functional` instance.
+func NewFunctional(f func(torch.Tensor) torch.Tensor) *Functional {
+	return &Functional{Module: Module{isTraining: true}, function: f}
+}
+
+// Forward feeds the `input` tensor to the underlying function.
+func (f *Functional) Forward(input torch.Tensor) torch.Tensor {
+	return f.function(input)
+}

--- a/nn/container.go
+++ b/nn/container.go
@@ -13,7 +13,9 @@ type Sequential struct {
 
 // NewSequential returns a new `Sequential` instance.
 func NewSequential(modules ...IModule) *Sequential {
-	return &Sequential{Module: Module{isTraining: true}, Modules: modules}
+	r := &Sequential{Module: Module{isTraining: true}, Modules: modules}
+	r.Init(r)
+	return r
 }
 
 // Forward feeds `inputs` to the first module and then chains outputs to inputs, returning the last output.
@@ -55,7 +57,9 @@ type Functional struct {
 
 // NewFunctional returns a new `Functional` instance.
 func NewFunctional(f func(torch.Tensor) torch.Tensor) *Functional {
-	return &Functional{Module: Module{isTraining: true}, function: f}
+	r := &Functional{Module: Module{isTraining: true}, function: f}
+	r.Init(r)
+	return r
 }
 
 // Forward feeds the `input` tensor to the underlying function.

--- a/nn/container_test.go
+++ b/nn/container_test.go
@@ -1,0 +1,79 @@
+package nn
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type layer1 struct {
+	Module
+}
+
+func (l *layer1) Forward(x, y int) (int64, int64) {
+	return int64(x), int64(y)
+}
+
+type layer2 struct {
+	Module
+}
+
+func (l *layer2) Forward(x, y int64) string {
+	return strconv.Itoa(int(x + y))
+}
+
+type layer3 struct {
+	Module
+}
+
+func (l *layer3) Forward(sum string) int {
+	r, e := strconv.Atoi(sum)
+	if e != nil {
+		return 42
+	}
+	return r
+}
+
+type model1 struct {
+	Module
+	module *Sequential
+}
+
+func (m *model1) Forward() int {
+	return m.module.Forward(1, 2).(int)
+}
+
+func TestSequential(t *testing.T) {
+	m := model1{module: NewSequential(&layer1{}, &layer2{}, &layer3{})}
+	assert.Equal(t, m.Forward(), 3)
+}
+
+type layer4 struct {
+	Module
+	module *Sequential
+}
+
+func (l *layer4) Forward(x, y int) string {
+	return l.module.Forward(x, y).(string)
+}
+
+type model2 struct {
+	Module
+	module *Sequential
+}
+
+func (l *model2) Forward(x, y int) int {
+	return l.module.Forward(x, y).(int)
+}
+
+func TestSequentialInSequential(t *testing.T) {
+	m := model2{
+		module: NewSequential(
+			&layer4{
+				module: NewSequential(&layer1{}, &layer2{}),
+			},
+			&layer3{}),
+	}
+	assert.Equal(t, m.Forward(1, 2), 3)
+}

--- a/nn/conv.go
+++ b/nn/conv.go
@@ -48,6 +48,7 @@ func NewConv2d(inChannels, outChannels, kernelSize, stride, padding, dilation,
 		bound := 1.0 / math.Sqrt(float64(fanIn))
 		initializer.Uniform(&c.Bias, -bound, bound)
 	}
+	c.Init(c)
 	return c
 }
 

--- a/nn/conv.go
+++ b/nn/conv.go
@@ -8,7 +8,9 @@ import (
 	"github.com/wangkuiyi/gotorch/nn/initializer"
 )
 
-type conv2d struct {
+// Conv2d applies convolution over a 2D input.
+type Conv2d struct {
+	Module
 	InChannels  int64
 	OutChannels int64
 	KernelSize  int64
@@ -21,12 +23,13 @@ type conv2d struct {
 	Bias        torch.Tensor
 }
 
-// Conv2d does conv2d computaion. torch.conv2d
+// NewConv2d creates a `Conv2d` instance
 // TODO(qijun): only support zero padding mode
 // only support symmetry kernel/stride/padding/dilation
-func Conv2d(inChannels, outChannels, kernelSize, stride, padding, dilation,
-	groups int64, bias bool, paddingMode string) Module {
-	c := &conv2d{
+func NewConv2d(inChannels, outChannels, kernelSize, stride, padding, dilation,
+	groups int64, bias bool, paddingMode string) *Conv2d {
+	c := &Conv2d{
+		Module:      Module{isTraining: true},
 		InChannels:  inChannels,
 		OutChannels: outChannels,
 		KernelSize:  kernelSize,
@@ -49,7 +52,7 @@ func Conv2d(inChannels, outChannels, kernelSize, stride, padding, dilation,
 }
 
 // Forward method
-func (c *conv2d) Forward(x torch.Tensor) torch.Tensor {
+func (c *Conv2d) Forward(x torch.Tensor) torch.Tensor {
 	return functional.Conv2d(x, c.Weight, c.Bias, []int64{c.Stride, c.Stride},
 		[]int64{c.Padding, c.Padding}, []int64{c.Dilation, c.Dilation}, c.Groups)
 }

--- a/nn/linear.go
+++ b/nn/linear.go
@@ -22,6 +22,7 @@ func NewLinear(in, out int64, bias bool) *Linear {
 	if bias {
 		l.Bias = torch.RandN([]int64{out, 1}, true)
 	}
+	l.Init(l)
 	return l
 }
 

--- a/nn/linear.go
+++ b/nn/linear.go
@@ -2,16 +2,19 @@ package nn
 
 import torch "github.com/wangkuiyi/gotorch"
 
-type linear struct {
+// Linear applies a linear transformation with optional bias.
+type Linear struct {
+	Module
 	InFeatures  int64
 	OutFeatures int64
 	Weight      torch.Tensor
 	Bias        torch.Tensor
 }
 
-// Linear creates a linear instance
-func Linear(in, out int64, bias bool) Module {
-	l := &linear{
+// NewLinear creates a `Linear` instance
+func NewLinear(in, out int64, bias bool) *Linear {
+	l := &Linear{
+		Module:      Module{isTraining: true},
 		InFeatures:  in,
 		OutFeatures: out,
 	}
@@ -22,7 +25,7 @@ func Linear(in, out int64, bias bool) Module {
 	return l
 }
 
-// Forward method
-func (l *linear) Forward(x torch.Tensor) torch.Tensor {
+// Forward does a linear transformation to the `input` tensor.
+func (l *Linear) Forward(x torch.Tensor) torch.Tensor {
 	return torch.MM(x, l.Weight)
 }

--- a/nn/module.go
+++ b/nn/module.go
@@ -7,9 +7,80 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 )
 
-// Module interface
-type Module interface {
-	Forward(x torch.Tensor) torch.Tensor
+// Dtype is the data type of scalars
+type Dtype int // TODO(shendiaomo): this is a placeholder to be defined later
+
+// DeviceType is the type of devices
+type DeviceType in // TODO(shendiaomo): this is a placeholder to be defined latert
+
+// DeviceIndex is the index of available devices
+type DeviceIndex = int16
+
+// Device represents a a compute device on which a tensor is located.
+type Device struct {
+	typ DeviceType
+	idx DeviceIndex
+}
+
+// IModule is the interface of `Module`s
+type IModule interface {
+	// Train enables "training" mode
+	Train(on bool)
+	// IsTraining returns true if the module is in training mode
+	IsTraining()
+	// To recursively casts all parameters to the given `dtype` and `device`.
+	To(device Device, dtype Dtype, nonBlocking bool)
+	// ZeroGrad recursively zeros out the `grad` value of each registered parameter.
+	ZeroGrad()
+	// String is for printing modules prettily
+	String() string
+}
+
+// Module contains default implementation of `Module`s
+type Module struct {
+	// Whether the module is in training mode.
+	isTraining bool
+
+	// The module's name (e.g. "LSTM").
+	name string
+
+	// The registered buffers of this `Module`.
+	buffers map[string]Tensor
+
+	// The registered (direct) submodules of this `Module`.
+	children map[string]IModule
+}
+
+// Forward returns the result of the forward pass of the modules
+func (m *Module) Forward(x Tensor) Tensor {
+	// TODO(shendiaomo): to be deleted, each container as `Sequential` etc.
+	// should use `reflect` to call `Forward` of submodules
+	return Tensor{}
+}
+
+// Train enables "training" mode
+func (m *Module) Train(on bool) {
+	m.isTraining = on
+}
+
+// IsTraining returns true if the module is in training mode
+func (m *Module) IsTraining() bool {
+	return m.isTraining
+}
+
+// To recursively casts all parameters to the given `dtype` and `device`.
+func (m *Module) To(device Device, dtype Dtype, nonBlocking bool) {
+	// TODO(shendiaomo): to be implemented
+}
+
+// ZeroGrad recursively zeros out the `grad` value of each registered parameter.
+func (m *Module) ZeroGrad() {
+	// TODO(shendiaomo): to be implemented
+}
+
+// String is for printing modules prettily
+func (m *Module) String() string {
+	// TODO(shendiaomo): to be implemented
 }
 
 // GetNamedParameters returns parameters in the module recursively.

--- a/nn/module.go
+++ b/nn/module.go
@@ -11,10 +11,10 @@ import (
 type Dtype int // TODO(shendiaomo): this is a placeholder to be defined later
 
 // DeviceType is the type of devices
-type DeviceType in // TODO(shendiaomo): this is a placeholder to be defined latert
+type DeviceType int // TODO(shendiaomo): this is a placeholder to be defined latert
 
 // DeviceIndex is the index of available devices
-type DeviceIndex = int16
+type DeviceIndex int16
 
 // Device represents a a compute device on which a tensor is located.
 type Device struct {

--- a/nn/module.go
+++ b/nn/module.go
@@ -45,17 +45,10 @@ type Module struct {
 	name string
 
 	// The registered buffers of this `Module`.
-	buffers map[string]Tensor
+	buffers map[string]torch.Tensor
 
 	// The registered (direct) submodules of this `Module`.
 	children map[string]IModule
-}
-
-// Forward returns the result of the forward pass of the modules
-func (m *Module) Forward(x Tensor) Tensor {
-	// TODO(shendiaomo): to be deleted, each container as `Sequential` etc.
-	// should use `reflect` to call `Forward` of submodules
-	return Tensor{}
 }
 
 // Train enables "training" mode

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -14,10 +14,10 @@ type myNet struct {
 
 func newMyNet() *myNet {
 	n := &myNet{
-		Module: Module{isTraining: true},
-		L1:     NewLinear(100, 200, false),
-		L2:     NewLinear(200, 10, false),
+		L1: NewLinear(100, 200, false),
+		L2: NewLinear(200, 10, false),
 	}
+	n.Init(n)
 	return n
 }
 
@@ -29,17 +29,17 @@ func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
 }
 
 type myNet2 struct {
-	*Module
+	Module
 	Weight torch.Tensor `gotorch:"buffer"`
 	L1     *Linear
 }
 
 func newMyNet2() *myNet2 {
 	n := &myNet2{
-		Module: &Module{isTraining: true},
 		Weight: torch.RandN([]int64{100, 200}, false),
 		L1:     NewLinear(100, 200, false),
 	}
+	n.Init(n)
 	return n
 }
 
@@ -50,17 +50,17 @@ func (n *myNet2) Forward(x torch.Tensor) torch.Tensor {
 }
 
 type hierarchyNet struct {
-	*Module
+	Module
 	L1 *myNet
 	L2 *Linear
 }
 
 func newHierarchyNet() *hierarchyNet {
 	n := &hierarchyNet{
-		Module: &Module{isTraining: true},
-		L1:     newMyNet(),
-		L2:     NewLinear(200, 10, false),
+		L1: newMyNet(),
+		L2: NewLinear(200, 10, false),
 	}
+	n.Init(n)
 	return n
 }
 
@@ -73,18 +73,19 @@ func (n *hierarchyNet) Forward(x torch.Tensor) torch.Tensor {
 
 func TestModule(t *testing.T) {
 	n := newMyNet()
-	namedParams := GetNamedParameters(n)
+	n.ZeroGrad()
+	namedParams := n.NamedParameters()
 	assert.Equal(t, 2, len(namedParams))
 	assert.Contains(t, namedParams, "myNet.L1.Weight")
 	assert.Contains(t, namedParams, "myNet.L2.Weight")
 
 	n2 := newMyNet2()
-	namedParams2 := GetNamedParameters(n2)
+	namedParams2 := n2.NamedParameters()
 	assert.Equal(t, 1, len(namedParams2))
 	assert.Contains(t, namedParams2, "myNet2.L1.Weight")
 
 	hn := newHierarchyNet()
-	hnNamedParams := GetNamedParameters(hn)
+	hnNamedParams := hn.NamedParameters()
 	assert.Equal(t, 3, len(hnNamedParams))
 	assert.Contains(t, hnNamedParams, "hierarchyNet.L1.L1.Weight")
 	assert.Contains(t, hnNamedParams, "hierarchyNet.L1.L2.Weight")

--- a/optim_test.go
+++ b/optim_test.go
@@ -18,6 +18,7 @@ func newMyNet() *myNet {
 		L1: nn.NewLinear(100, 200, false),
 		L2: nn.NewLinear(200, 10, false),
 	}
+	n.Init(n)
 	return n
 }
 
@@ -30,11 +31,11 @@ func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
 
 func ExampleSGD() {
 	net := newMyNet()
-	np := nn.GetNamedParameters(net)
+	np := net.NamedParameters()
 	fmt.Println(len(np))
 
 	opt := torch.SGD(0.1, 0, 0, 0, false)
-	opt.AddParameters(nn.GetParameters(net))
+	opt.AddParameters(net.Parameters())
 
 	for i := 0; i < 100; i++ {
 		torch.GC()
@@ -48,8 +49,6 @@ func ExampleSGD() {
 	}
 	torch.FinishGC()
 	opt.Close()
-	nn.CloseModule(net)
-
 	// Output:
 	// 2
 }

--- a/optim_test.go
+++ b/optim_test.go
@@ -8,14 +8,15 @@ import (
 )
 
 type myNet struct {
-	L1, L2 nn.Module
+	nn.Module
+	L1, L2 *nn.Linear
 }
 
 // MyNet returns a MyNet instance
-func MyNet() nn.Module {
+func newMyNet() *myNet {
 	n := &myNet{
-		L1: nn.Linear(100, 200, false),
-		L2: nn.Linear(200, 10, false),
+		L1: nn.NewLinear(100, 200, false),
+		L2: nn.NewLinear(200, 10, false),
 	}
 	return n
 }
@@ -28,7 +29,7 @@ func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
 }
 
 func ExampleSGD() {
-	net := MyNet()
+	net := newMyNet()
 	np := nn.GetNamedParameters(net)
 	fmt.Println(len(np))
 


### PR DESCRIPTION
1. This PR has both `IModule` and `Module`, the former is the interface, the latter is to ease implementation.
    - The `IModule` interface exposes much fewer methods than in the C++/Python `Module` class, other methods will be added later when necessary.
2. This PR adds the `Sequential` container, whose `Forward` method is based on `reflect`. We use `reflect` rather than polymorphism to implement the `Forward` method to give users complete freedom to design their `Forward` methods. This behavior is the same as the Python/C++ frontend of PyTorch.
    - Therefore, the `getNamedNonNilTensors` function in module.go is also modified to support introspecting the `slice`s in an `IModule`.
    - This PR also adds a `Sequential` based example of MNIST for demo.
    