### PR TITLE
Upgrade libtorch to 1.6.0

### DIFF
--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -1,9 +1,9 @@
 all : libcgotorch.so
 
-libtorch-macos-1.5.1.zip :
-	curl -LsO https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.5.1.zip
+libtorch-macos-1.6.0.zip :
+	curl -LsO https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.6.0.zip
 
-macos/libtorch : libtorch-macos-1.5.1.zip
+macos/libtorch : libtorch-macos-1.6.0.zip
 	unzip -qq -o $< -d macos
 
 libcgotorch.so : cgotorch.cc cgotorch.h macos/libtorch

--- a/cgotorch/Makefile.linux
+++ b/cgotorch/Makefile.linux
@@ -1,9 +1,9 @@
 all : libcgotorch.so
 
-libtorch-shared-with-deps-1.5.1%2Bcpu.zip :
-	curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.5.1%2Bcpu.zip'
+libtorch-shared-with-deps-1.6.0%2Bcpu.zip :
+	curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.6.0%2Bcpu.zip'
 
-linux/libtorch : libtorch-shared-with-deps-1.5.1%2Bcpu.zip
+linux/libtorch : libtorch-shared-with-deps-1.6.0%2Bcpu.zip
 	unzip -qq -o $< -d linux
 
 libcgotorch.so : cgotorch.cc cgotorch.h linux/libtorch


### PR DESCRIPTION
`Makefile.rpi` is using pre-built libtorch 1.6.0 for ARM/Linux. Let us unify the version used by `Makefile{,linux,rpi}`.