### PR TITLE
Add a simple MNIST benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -21,8 +21,8 @@ of the GoTorch program is about **3 times** of the PyTorch version.  The measure
 of throughput doesn't include model instantiaation, data preparation, but only
 the train loop.
 
-Consider the tatal running time, the GoTorch version takes 43 seconds, but the
-PyTorch version takes 4 minutes.
+Consider the tatal running time, the GoTorch version takes **43 seconds**, but
+the PyTorch version takes about **4 minutes**.
 
 A typical run outputs the following:
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -16,6 +16,14 @@ time python benchmark/mnist.py
 
 Both programs use only CPU but no GPU.
 
+Because the GoTorch version uses libtorch 1.6.0, please make sure you have
+PyTorch 1.6.0 installed for the PyTorch version.  Also, both GoTorch and PyTorch
+versions use the data loader from torchvision.
+
+```bash
+python3 -m pip install torch==1.6.0 torchvision
+```
+
 On a Late 2014 MacBook Pro runninng macOS 10.15.5, it seems that the throughtput
 of the GoTorch program is about **3 times** of the PyTorch version.  The measure
 of throughput doesn't include model instantiaation, data preparation, but only

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,45 @@
+# Benchmarking: GoTorch v.s. PyTorch
+
+To run the GoTorch version of MNIST training with 5 epochs, type the following
+command:
+
+```bash
+time go test -v -run TrainMNIST
+```
+
+To run the Python version of MNIST training with the same parameters, network
+structure, and dataset, type the following command:
+
+```bash
+time python benchmark/mnist.py
+```
+
+Both programs use only CPU but no GPU.
+
+On a Late 2014 MacBook Pro runninng macOS 10.15.5, it seems that the throughtput
+of the GoTorch program is about **3 times** of the PyTorch version.  The measure
+of throughput doesn't include model instantiaation, data preparation, but only
+the train loop.
+
+Consider the tatal running time, the GoTorch version takes 43 seconds, but the
+PyTorch version takes 4 minutes.
+
+A typical run outputs the following:
+
+```
+yi@WangYis-iMac:~/go/src/github.com/wangkuiyi/gotorch (benchmark)*$ time python benchmark/mnist.py
+The throughput: 4177.628869040359 samples/sec
+
+real    1m22.022s
+user    3m59.016s
+sys 0m11.934s
+
+yi@WangYis-iMac:~/go/src/github.com/wangkuiyi/gotorch (benchmark)*$ time go test -run TrainMNIST
+2020/08/11 09:40:21 Throughput: 13129.192544 samples/sec
+PASS
+ok      github.com/wangkuiyi/gotorch    23.755s
+
+real    0m24.871s
+user    0m43.235s
+sys 0m37.307s
+```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -24,10 +24,9 @@ versions use the data loader from torchvision.
 python3 -m pip install torch==1.6.0 torchvision
 ```
 
-On a Late 2014 MacBook Pro runninng macOS 10.15.5, it seems that the throughtput
-of the GoTorch program is about **3 times** of the PyTorch version.  The measure
-of throughput doesn't include model instantiaation, data preparation, but only
-the train loop.
+On a Late 2014 iMac runninng macOS 10.15.5, the throughtput of the GoTorch
+program is about **3 times** of the PyTorch version.  The measure of throughput
+doesn't include model instantiaation, data preparation, but only the train loop.
 
 Consider the tatal running time, the GoTorch version takes **43 seconds**, but
 the PyTorch version takes about **4 minutes**.

--- a/benchmark/mnist.py
+++ b/benchmark/mnist.py
@@ -54,6 +54,7 @@ def main():
             loss = F.nll_loss(output, target)
             loss.backward()
             optimizer.step()
+
     throughput = len(dataset) * epochs * 1.0 / (time.time() - start)
     print("The throughput: {} samples/sec".format(throughput))
 

--- a/benchmark/mnist.py
+++ b/benchmark/mnist.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+from torchvision import datasets, transforms
+import os
+import pathlib
+import time
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.fc1 = nn.Linear(28 * 28, 512)
+        self.fc2 = nn.Linear(512, 512)
+        self.fc3 = nn.Linear(512, 10)
+
+    def forward(self, x):
+        x = x.view((-1, 28 * 28,))
+        x = self.fc1(x)
+        x = torch.tanh(x)
+        x = self.fc2(x)
+        x = torch.tanh(x)
+        x = self.fc3(x)
+        return F.log_softmax(x, dim=1)
+
+
+def main():
+    device = torch.device("cpu")
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+
+    cache_dir = os.path.join(str(pathlib.Path.home()), ".cache/mnist")
+    dataset = datasets.MNIST(cache_dir, train=True, download=True,
+                             transform=transform)
+
+    train_loader = torch.utils.data.DataLoader(dataset, batch_size=64)
+
+    model = Net().to(device)
+    model.train()
+    optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
+
+    start = time.time()
+    epochs = 5
+    for epoch in range(epochs):
+        for batch_idx, (data, target) in enumerate(train_loader):
+            data, target = data.to(device), target.to(device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = F.nll_loss(output, target)
+            loss.backward()
+            optimizer.step()
+    throughput = len(dataset) * epochs * 1.0 / (time.time() - start)
+    print("The throughput: {} samples/sec".format(throughput))
+
+
+if __name__ == '__main__':
+    main()

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -2,6 +2,7 @@ package gotorch_test
 
 import (
 	"log"
+	"time"
 
 	torch "github.com/wangkuiyi/gotorch"
 	nn "github.com/wangkuiyi/gotorch/nn"
@@ -34,13 +35,16 @@ func ExampleTrainMNIST() {
 	if e := downloadMNIST(); e != nil {
 		log.Printf("Cannot find or download MNIST dataset: %v", e)
 	}
-	net := NewMNISTNet()
 	transforms := []torch.Transform{torch.NewNormalize(0.1307, 0.3081)}
 	mnist := torch.NewMNIST(dataDir(), transforms)
+
+	net := NewMNISTNet()
 	opt := torch.SGD(0.1, 0.5, 0, 0, false)
 	opt.AddParameters(nn.GetParameters(net))
-	epochs := 4
+
+	epochs := 5
 	batchIdx := 0
+	startTime := time.Now()
 	for i := 0; i < epochs; i++ {
 		trainLoader := torch.NewDataLoader(mnist, 64)
 		for trainLoader.Scan() {
@@ -54,6 +58,9 @@ func ExampleTrainMNIST() {
 		}
 		trainLoader.Close()
 	}
+	log.Printf("Throughput: %f samples/sec",
+		float64(60000*epochs)/float64(time.Since(startTime).Seconds()))
+
 	mnist.Close()
 	torch.FinishGC()
 	// Output:

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -56,7 +56,7 @@ func ExampleTrainMNIST() {
 		}
 		trainLoader.Close()
 	}
-	throughput := float64(60000*epochs) / float64(time.Since(startTime).Seconds())
+	throughput := float64(60000*epochs) / time.Since(startTime).Seconds()
 	log.Printf("Throughput: %f samples/sec", throughput)
 
 	mnist.Close()


### PR DESCRIPTION
The GoTorch version has a higher throughput that is 2~3 times higher than the PyTorch version.  Also, the GoTorch version has much shorter total running time than the PyTorch one.

On my quad-core iMac, we can see that the GoTorch version takes significantly higher ratio of system time than the PyTorch version.  The second peak in the following figure corresponds to the run of the GoTroch version; the third one to the PyTorch one.

![2041597175957_ pic](https://user-images.githubusercontent.com/1548775/89943232-bdabf600-dbd2-11ea-859a-fa9dd02943dd.jpg)
