### PR TITLE
tensor.To() to copy the Tensor memory to a specify device

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -10,11 +10,13 @@ typedef at::Tensor *Tensor;
 typedef torch::optim::Optimizer *Optimizer;
 typedef torch::data::datasets::MNIST *MNIST;
 typedef torch::data::transforms::Normalize<> *Normalize;
+typedef torch::Device *Device;
 #else
 typedef void *Tensor;
 typedef void *Optimizer;
 typedef void *MNIST;
 typedef void *Normalize;
+typedef void *Device;
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -61,8 +63,6 @@ void FreeString(const char *s);
 void Tensor_Backward(Tensor a);
 Tensor Tensor_Grad(Tensor a);
 
-void ManualSeed(int64_t seed);
-
 ////////////////////////////////////////////////////////////////////////////////
 // torch.nn.init
 ////////////////////////////////////////////////////////////////////////////////
@@ -77,6 +77,7 @@ const char *KaimingUniform_(double a, const char *fan_mod,
 const char *CalculateFanInAndFanOut(Tensor tensor, int64_t *fan_in,
                                     int64_t *fan_out);
 
+void ManualSeed(int64_t seed);
 ////////////////////////////////////////////////////////////////////////////////
 // torch.nn.functional
 ////////////////////////////////////////////////////////////////////////////////
@@ -121,6 +122,14 @@ void Optimizer_Step(Optimizer opt);
 void Optimizer_AddParameters(Optimizer opt, Tensor *tensors, int64_t length);
 void Optimizer_Close(Optimizer opt);
 
+////////////////////////////////////////////////////////////////////////////////
+// Device
+////////////////////////////////////////////////////////////////////////////////
+
+const char *Torch_Device(const char *device_type, Device *device);
+bool IsCUDAAvailable();
+
+const char *Tensor_To(Tensor input, Device device, Tensor *output);
 ////////////////////////////////////////////////////////////////////////////////
 //  Dataset, DataLoader, and Iterator torch.utils.data
 ////////////////////////////////////////////////////////////////////////////////

--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -255,3 +255,33 @@ bool Loader_Next(DataLoader loader, Iterator iter) {
 void Loader_Close(DataLoader loader) {
   delete static_cast<TypeDataLoader *>(loader);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Device
+////////////////////////////////////////////////////////////////////////////////
+std::unordered_map<std::string, torch::DeviceType> device_type_map = {
+    {"cpu", torch::kCPU}, {"cuda", torch::kCUDA}};
+
+const char *Torch_Device(const char *device_type, Device *device) {
+  try {
+    if (device_type_map.count(std::string(device_type)) == 0) {
+      return exception_str("Excepted one of cpu, cuda device type.");
+    }
+    *device = new torch::Device(device_type_map[std::string(device_type)]);
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+  return nullptr;
+}
+
+bool IsCUDAAvailable() { return torch::cuda::is_available(); }
+
+const char *Tensor_To(Tensor input, Device device, Tensor *output) {
+  try {
+    auto result = input->to(*device, input->dtype());
+    *output = new at::Tensor(result);
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}

--- a/device.go
+++ b/device.go
@@ -1,0 +1,28 @@
+package gotorch
+
+// #cgo CFLAGS: -I ${SRCDIR}/cgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/cgotorch -Wl,-rpath ${SRCDIR}/cgotorch -lcgotorch
+// #cgo LDFLAGS: -L ${SRCDIR}/cgotorch/libtorch/lib -Wl,-rpath ${SRCDIR}/cgotorch/libtorch/lib -lc10 -ltorch -ltorch_cpu
+// #include "cgotorch.h"
+import "C"
+import "unsafe"
+
+// Device wrapper a pointer to C.Device
+type Device struct {
+	T C.Device
+}
+
+// NewDevice returns a Device
+func NewDevice(deviceType string) Device {
+	var t C.Device
+	MustNil(unsafe.Pointer(C.Torch_Device(C.CString(deviceType), &t)))
+	return Device{t}
+}
+
+// IsCUDAAvailable returns true if CUDA is availabl
+func IsCUDAAvailable() bool {
+	if C.IsCUDAAvailable() == C.bool(true) {
+		return true
+	}
+	return false
+}

--- a/device_test.go
+++ b/device_test.go
@@ -1,0 +1,30 @@
+package gotorch_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	torch "github.com/wangkuiyi/gotorch"
+)
+
+func TestDevice(t *testing.T) {
+	a := assert.New(t)
+	var device torch.Device
+	if torch.IsCUDAAvailable() {
+		device = torch.NewDevice("cuda")
+	} else {
+		device = torch.NewDevice("cpu")
+	}
+	a.NotNil(device)
+	x := torch.RandN([]int64{2, 3}, false)
+	x.To(device)
+}
+
+func TestPanicDevice(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("TestPanicDevice should have paniced")
+		}
+	}()
+	torch.NewDevice("unknown")
+}

--- a/device_test.go
+++ b/device_test.go
@@ -10,24 +10,22 @@ import (
 
 func TestDevice(t *testing.T) {
 	a := assert.New(t)
-	var device torch.Device
-	if torch.IsCUDAAvailable() {
-		log.Println("CUDA is valid")
-		device = torch.NewDevice("cuda")
-	} else {
-		log.Println("No CUDA found; CPU only")
-		device = torch.NewDevice("cpu")
-	}
-	a.NotNil(device)
-	x := torch.RandN([]int64{2, 3}, false)
-	x.To(device)
+	a.NotPanics(func() {
+		var device torch.Device
+		if torch.IsCUDAAvailable() {
+			log.Println("CUDA is valid")
+			device = torch.NewDevice("cuda")
+		} else {
+			log.Println("No CUDA found; CPU only")
+			device = torch.NewDevice("cpu")
+		}
+		torch.RandN([]int64{2, 3}, false).To(device)
+	})
 }
 
 func TestPanicDevice(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("TestPanicDevice should have paniced")
-		}
-	}()
-	torch.NewDevice("unknown")
+	a := assert.New(t)
+	a.Panics(func() {
+		torch.NewDevice("unknown")
+	}, "TestPanicDevice should panics")
 }

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -98,7 +98,7 @@ func ExampleTrainMNISTSequential() {
 	mnist := torch.NewMNIST(dataDir(), transforms)
 	opt := torch.SGD(0.1, 0.5, 0, 0, false)
 	opt.AddParameters(net.Parameters())
-	epochs := 4
+	epochs := 1
 	startTime := time.Now()
 	for i := 0; i < epochs; i++ {
 		trainLoader := torch.NewDataLoader(mnist, 64)

--- a/nn/conv.go
+++ b/nn/conv.go
@@ -57,3 +57,63 @@ func (c *Conv2d) Forward(x torch.Tensor) torch.Tensor {
 	return functional.Conv2d(x, c.Weight, c.Bias, []int64{c.Stride, c.Stride},
 		[]int64{c.Padding, c.Padding}, []int64{c.Dilation, c.Dilation}, c.Groups)
 }
+
+// ConvTranspose2dModule corresponds to torch.nn.ConvTranspose2d
+type ConvTranspose2dModule struct {
+	Module
+	InChannels  int64
+	OutChannels int64
+	KernelSize  int64
+	Stride      int64
+	Padding     int64
+	OutPadding  int64
+	Groups      int64
+	Dilation    int64
+	PaddingMode string
+	Weight      torch.Tensor
+	Bias        torch.Tensor
+}
+
+// ConvTranspose2d torch.nn.conv_transpose2d
+// TODO(qijun): only support zero padding mode
+// only support symmetry kernel/stride/padding/dilation
+// not support output_size when forwarding
+func ConvTranspose2d(inChannels, outChannels, kernelSize, stride, padding,
+	outPadding, groups int64, bias bool, dilation int64, paddingMode string) *ConvTranspose2dModule {
+	c := &ConvTranspose2dModule{
+		InChannels:  inChannels,
+		OutChannels: outChannels,
+		KernelSize:  kernelSize,
+		Stride:      stride,
+		Padding:     padding,
+		OutPadding:  outPadding,
+		Groups:      groups,
+		Dilation:    dilation,
+		PaddingMode: "zeros",
+	}
+	c.Weight = torch.Empty([]int64{inChannels, outChannels / groups, kernelSize,
+		kernelSize}, true)
+	if bias {
+		c.Bias = torch.Empty([]int64{outChannels}, true)
+	}
+	c.ResetParameters()
+	return c
+}
+
+// ResetParameters method
+func (c *ConvTranspose2dModule) ResetParameters() {
+	initializer.KaimingUniform(&c.Weight, math.Sqrt(5.0), "fan_in", "leaky_relu")
+	if c.Bias.T != nil {
+		fanIn, _ := initializer.CalculateFanInAndFanOut(c.Weight)
+		bound := 1.0 / math.Sqrt(float64(fanIn))
+		initializer.Uniform(&c.Bias, -bound, bound)
+	}
+	c.Init(c)
+}
+
+// Forward method
+func (c *ConvTranspose2dModule) Forward(x torch.Tensor) torch.Tensor {
+	return functional.ConvTranspose2d(x, c.Weight, c.Bias,
+		[]int64{c.Stride, c.Stride}, []int64{c.Padding, c.Padding},
+		[]int64{c.OutPadding, c.OutPadding}, c.Groups, []int64{c.Dilation, c.Dilation})
+}

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -98,3 +98,10 @@ func TestConv2d(t *testing.T) {
 	output := c.Forward(x)
 	assert.NotNil(t, output)
 }
+
+func TestConvTranspose2d(t *testing.T) {
+	c := ConvTranspose2d(16, 33, 3, 2, 0, 1, 1, true, 1, "zeros")
+	x := torch.RandN([]int64{20, 16, 50, 100}, false)
+	output := c.Forward(x)
+	assert.NotNil(t, output)
+}

--- a/tensor.go
+++ b/tensor.go
@@ -218,6 +218,14 @@ func (a Tensor) Grad() Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
+// To returns a Tensor with the specify device
+func (a Tensor) To(device Device) Tensor {
+	var t C.Tensor
+	MustNil(unsafe.Pointer(C.Tensor_To(C.Tensor(*a.T), device.T, &t)))
+	SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return Tensor{(*unsafe.Pointer)(&t)}
+}
+
 // MM multiplies each element of the input two tensors
 func MM(a, b Tensor) Tensor {
 	var t C.Tensor
@@ -282,4 +290,9 @@ func View(a Tensor, shape []int64) Tensor {
 	MustNil(unsafe.Pointer(C.View(C.Tensor(*a.T), &t, (*C.int64_t)(unsafe.Pointer(&shape[0])), C.int64_t(len(shape)))))
 	SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return Tensor{(*unsafe.Pointer)(&t)}
+}
+
+// To copy Tensor memory to the specify device
+func To(a Tensor, device Device) Tensor {
+	return a.To(device)
 }

--- a/tensor.go
+++ b/tensor.go
@@ -218,7 +218,8 @@ func (a Tensor) Grad() Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// To returns a Tensor with the specify device
+// To returns a Tensor on the specified device with the same content as the a.
+// If the specified device doesn't exist, To panics.
 func (a Tensor) To(device Device) Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Tensor_To(C.Tensor(*a.T), device.T, &t)))
@@ -292,7 +293,8 @@ func View(a Tensor, shape []int64) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// To copy Tensor memory to the specify device
+// To returns a Tensor on the specified device with the same content as the a.
+// If the specified device doesn't exist, To panics.
 func To(a Tensor, device Device) Tensor {
 	return a.To(device)
 }


### PR DESCRIPTION
related issued #123 
Users can specify a Tensor device like:

``` golang
device := torch.NewDevice("cuda")
x := torch.RandN([]int64{2,3}).To(device)
...
```