### PR TITLE
Fix linear argument

### DIFF
--- a/mnist_test.go
+++ b/mnist_test.go
@@ -18,9 +18,9 @@ type MLPMNISTNet struct {
 
 func NewMNISTNet() *MLPMNISTNet {
 	r := &MLPMNISTNet{
-		FC1: nn.Linear(28*28, 512, false),
-		FC2: nn.Linear(512, 512, false),
-		FC3: nn.Linear(512, 10, false)}
+		FC1: nn.Linear(28*28, 512, true),
+		FC2: nn.Linear(512, 512, true),
+		FC3: nn.Linear(512, 10, true)}
 	r.Init(r)
 	return r
 }
@@ -35,7 +35,7 @@ func (n *MLPMNISTNet) Forward(x torch.Tensor) torch.Tensor {
 	return x.LogSoftmax(1)
 }
 
-func ExampleTrainMNIST() {
+func ExampleTrainMNISTMLP() {
 	if e := vision.DownloadMNIST(); e != nil {
 		log.Printf("Cannot find or download MNIST dataset: %v", e)
 	}

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -35,7 +35,7 @@ func (n *MLPMNISTNet) Forward(x torch.Tensor) torch.Tensor {
 	return x.LogSoftmax(1)
 }
 
-func ExampleTrainMNISTMLP() {
+func ExampleTrainMLPUsingMNIST() {
 	if e := vision.DownloadMNIST(); e != nil {
 		log.Printf("Cannot find or download MNIST dataset: %v", e)
 	}

--- a/nn/linear.go
+++ b/nn/linear.go
@@ -26,7 +26,7 @@ func Linear(in, out int64, bias bool) *LinearModule {
 	}
 	l.Weight = torch.Empty([]int64{out, in}, true)
 	if bias {
-		l.Bias = torch.Empty([]int64{out, 1}, true)
+		l.Bias = torch.Empty([]int64{out}, true)
 	}
 	l.Init(l)
 	l.resetParameters()


### PR DESCRIPTION
related  issue #113 

This PR fixed the problem that the initialized weight of FC layers are different between C++ and Go. And the MNIST example gets a  closer loss to the C++ version, we should continue to find out the reason to let  C++ and Go got the same loss.

Gotorch MNIST example  loss:

``` text
2020/08/15 23:45:41 Epoch: 0, Loss: 0.1583
2020/08/15 23:45:46 Epoch: 1, Loss: 0.0852
```