### PR TITLE
fix default sampler in MNIST dataset

### DIFF
--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -269,7 +269,9 @@ using TypeIterator = torch::data::Iterator<TypeDataLoader::BatchType>;
 DataLoader MakeDataLoader(Dataset dataset, int64_t batchsize) {
   auto map_dataset = dataset.p->map(*dataset.normalize)
                          .map(torch::data::transforms::Stack<>());
-  auto p = torch::data::make_data_loader(map_dataset, batchsize);
+  auto p =
+      torch::data::make_data_loader<torch::data::samplers::SequentialSampler>(
+          map_dataset, batchsize);
   return p.release();
 }
 


### PR DESCRIPTION
fixed #113 

GoTorch got the same loss value with the C++ MNIST example.

``` text
➜  gotorch git:(develop) ✗ go  test -run ExampleTrainMLPUsingMNIST -v
=== RUN   ExampleTrainMLPUsingMNIST
2020/08/17 16:02:20 No CUDA found; CPU only
2020/08/17 16:02:25 Epoch: 0, Loss: 0.1280
2020/08/17 16:02:30 Epoch: 1, Loss: 0.0659
```