### PR TITLE
Enable tracing on MNIST training example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data
 .DS_store
 *.png
 *.pt
+trace.out

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -1,7 +1,11 @@
 package gotorch_test
 
 import (
+	"flag"
 	"log"
+	"os"
+	"runtime/trace"
+	"testing"
 	"time"
 
 	torch "github.com/wangkuiyi/gotorch"
@@ -10,6 +14,9 @@ import (
 	"github.com/wangkuiyi/gotorch/nn/initializer"
 	"github.com/wangkuiyi/gotorch/vision"
 )
+
+var enableTrace bool
+var maxIters int
 
 type MLPMNISTNet struct {
 	nn.Module
@@ -36,6 +43,7 @@ func (n *MLPMNISTNet) Forward(x torch.Tensor) torch.Tensor {
 }
 
 func ExampleTrainMLPUsingMNIST() {
+
 	if e := vision.DownloadMNIST(); e != nil {
 		log.Printf("Cannot find or download MNIST dataset: %v", e)
 	}
@@ -59,6 +67,20 @@ func ExampleTrainMLPUsingMNIST() {
 	epochs := 2
 	startTime := time.Now()
 	var lastLoss float32
+	if enableTrace {
+		f, err := os.Create("trace.out")
+		if err != nil {
+			panic(err)
+		}
+		defer f.Close()
+
+		err = trace.Start(f)
+		if err != nil {
+			panic(err)
+		}
+		defer trace.Stop()
+	}
+	iters := 0
 	for epoch := 0; epoch < epochs; epoch++ {
 		trainLoader := torch.NewDataLoader(mnist, 64)
 		for trainLoader.Scan() {
@@ -69,9 +91,16 @@ func ExampleTrainMLPUsingMNIST() {
 			loss.Backward()
 			opt.Step()
 			lastLoss = loss.Item()
+			if iters == maxIters && enableTrace {
+				break
+			}
+			iters++
 		}
 		log.Printf("Epoch: %d, Loss: %.4f", epoch, lastLoss)
 		trainLoader.Close()
+		if iters == maxIters && enableTrace {
+			break
+		}
 	}
 	throughput := float64(60000*epochs) / time.Since(startTime).Seconds()
 	log.Printf("Throughput: %f samples/sec", throughput)
@@ -126,4 +155,11 @@ func ExampleTrainMNISTSequential() {
 	mnist.Close()
 	torch.FinishGC()
 	// Output:
+}
+
+func init() {
+	testing.Init()
+	flag.BoolVar(&enableTrace, "trace", false, "enable trace runtime")
+	flag.IntVar(&maxIters, "max-iters", 10, "max iterators for tracing")
+	flag.Parse()
 }


### PR DESCRIPTION
This PR enable tracing GoTorch program using [Golang trace package](https://golang.org/pkg/runtime/trace/) as the following command:

``` bash
$ go test -run ExampleTrainMLPUsingMNIST -v -args -trace -max-iters=10
```

The above command would generate a `trace.out` file, we can load it by command:

``` bash
$ go tool trace trace.out
```

then, the go command-line would open a web page in your browser like the following figure

![image](https://user-images.githubusercontent.com/1426912/90395674-79838e80-e0c7-11ea-99d1-6cf072783ffb.png)


The **Scheduler latency profile **  shows function calls that led to blocking on synchronization:

![image](https://user-images.githubusercontent.com/1426912/90395770-af287780-e0c7-11ea-81b3-62cdf6ed3430.png)

From  the above figure, we can find the `SetTensorFinalizer` cost the most time, we can do more iterations and compare the wall time on `SetTensorFinalizer`

| maxIters=10 |  maxIters=100 | maxIters=500| maxIters=1k|
|-- | -- |  -- |  -- |
| 85.52% | 93.17% | 94.10% | 94.61%|
