### PR TITLE
Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/golang:1.15
 
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /go/src/github.com/wangkuiyi/gotorch
     steps:
       - checkout
       - run: cgotorch/build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.15
+
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+      - run: cgotorch/build.sh
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -6,7 +6,7 @@ pushd $DIR
 
 OS=$(uname | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
-CXX="clang++"
+CXX="g++"
 LIBTORCH_DIR=""
 GLIBCXX_USE_CXX11_ABI="1"
 LOAD="force_load"
@@ -16,7 +16,6 @@ INSTALL_NAME=""
 if [ "$OS" == "linux" ]; then
     if [ "$ARCH" == "arm" ]; then
         echo "Building for Raspbian ...";
-        CXX="g++"
         LIBTORCH_DIR="rpi/libtorch"
         if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
             curl -LsO 'https://github.com/ljk53/pytorch-rpi/raw/master/libtorch-rpi-cxx11-abi-shared-1.6.0.zip';

--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -22,22 +22,22 @@ if [ "$OS" == "linux" ]; then
             unzip -qq -o libtorch-rpi-cxx11-abi-shared-1.6.0.zip -d rpi
         fi
     elif $(whereis cuda | cut -f 2 -d ' ')/bin/nvcc --version > /dev/null; then
-	    CUDA_VERSION=`nvcc --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1`
-	    if [ "$CUDA_VERSION" == "10.1" ]; then
+        CUDA_VERSION=`nvcc --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1`
+        if [ "$CUDA_VERSION" == "10.1" ]; then
             echo "Building for Linux with CUDA 10.1";
             LIBTORCH_DIR="linux-cuda101/libtorch"
             if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
                 curl -Lso libtorch-cxx11-1.6.0-linux-cuda101.zip 'https://download.pytorch.org/libtorch/cu101/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcu101.zip'
                 unzip -qq -o libtorch-cxx11-1.6.0-linux-cuda101.zip -d linux-cuda101
             fi
-	    elif [ "$CUDA_VERSION" == "10.2" ]; then
-	        echo "Building for Linux with CUDA 10.2";
+        elif [ "$CUDA_VERSION" == "10.2" ]; then
+            echo "Building for Linux with CUDA 10.2";
             LIBTORCH_DIR="linux-cuda102/libtorch"
             if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
                 curl -Lso libtorch-cxx11-1.6.0-linux-cuda102.zip 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip'
                 unzip -qq -o libtorch-cxx11-1.6.0-linux-cuda102.zip -d linux-cuda102
             fi
-	    fi
+        fi
     else
         echo "Building for Linux without CUDA ...";
         LIBTORCH_DIR="linux/libtorch"
@@ -60,11 +60,11 @@ elif [ "$OS" == "darwin" ]; then
 fi
 
 make CXX="$CXX" \
-    LIB_SUFFIX="$LIB_SUFFIX" \
-    INSTALL_NAME="$INSTALL_NAME" \
-    LIBTORCH_DIR="$LIBTORCH_DIR" \
-    GLIBCXX_USE_CXX11_ABI="$GLIBCXX_USE_CXX11_ABI" \
-    LOAD="$LOAD" \
-    -f Makefile;
+     LIB_SUFFIX="$LIB_SUFFIX" \
+     INSTALL_NAME="$INSTALL_NAME" \
+     LIBTORCH_DIR="$LIBTORCH_DIR" \
+     GLIBCXX_USE_CXX11_ABI="$GLIBCXX_USE_CXX11_ABI" \
+     LOAD="$LOAD" \
+     -f Makefile;
 
 popd


### PR DESCRIPTION
CircleCI runs way faster than Travis CI because CircleCI runs in Docker containers instead of VMs. However, the benefit of running VM is to add macOS and ARM64 tests.

Should we have CircleCI runs Linux without CUDA tests, and, optionally, Travis CI runs macOS and ARM tests?