### PR TITLE
Use pprof for benchmark analysis

### DIFF
--- a/mnist_test.go
+++ b/mnist_test.go
@@ -1,11 +1,7 @@
 package gotorch_test
 
 import (
-	"flag"
 	"log"
-	"os"
-	"runtime/trace"
-	"testing"
 	"time"
 
 	torch "github.com/wangkuiyi/gotorch"
@@ -14,9 +10,6 @@ import (
 	"github.com/wangkuiyi/gotorch/nn/initializer"
 	"github.com/wangkuiyi/gotorch/vision"
 )
-
-var enableTrace bool
-var maxIters int
 
 type MLPMNISTNet struct {
 	nn.Module
@@ -43,7 +36,6 @@ func (n *MLPMNISTNet) Forward(x torch.Tensor) torch.Tensor {
 }
 
 func ExampleTrainMLPUsingMNIST() {
-
 	if e := vision.DownloadMNIST(); e != nil {
 		log.Printf("Cannot find or download MNIST dataset: %v", e)
 	}
@@ -67,19 +59,6 @@ func ExampleTrainMLPUsingMNIST() {
 	epochs := 2
 	startTime := time.Now()
 	var lastLoss float32
-	if enableTrace {
-		f, err := os.Create("trace.out")
-		if err != nil {
-			panic(err)
-		}
-		defer f.Close()
-
-		err = trace.Start(f)
-		if err != nil {
-			panic(err)
-		}
-		defer trace.Stop()
-	}
 	iters := 0
 	for epoch := 0; epoch < epochs; epoch++ {
 		trainLoader := torch.NewDataLoader(mnist, 64)
@@ -92,16 +71,10 @@ func ExampleTrainMLPUsingMNIST() {
 			loss.Backward()
 			opt.Step()
 			lastLoss = loss.Item()
-			if iters == maxIters && enableTrace {
-				break
-			}
 			iters++
 		}
 		log.Printf("Epoch: %d, Loss: %.4f", epoch, lastLoss)
 		trainLoader.Close()
-		if iters == maxIters && enableTrace {
-			break
-		}
 	}
 	throughput := float64(60000*epochs) / time.Since(startTime).Seconds()
 	log.Printf("Throughput: %f samples/sec", throughput)
@@ -156,11 +129,4 @@ func ExampleTrainMNISTSequential() {
 	mnist.Close()
 	torch.FinishGC()
 	// Output:
-}
-
-func init() {
-	testing.Init()
-	flag.BoolVar(&enableTrace, "trace", false, "enable trace runtime")
-	flag.IntVar(&maxIters, "max-iters", 10, "max iterators for tracing")
-	flag.Parse()
 }


### PR DESCRIPTION
1. On my iMac, the GoTorch version of MNIST training has throughput close to that of the C++ counterpart.
1. On my iMac, the GoTorch and C++ versions are times faster than the PyTorch version.  As previously noticed and analyzed, the is likely due to that pip-installed PyTorch doesn't have a highly optimized libtorch shipped with it.
1. The GoTorch version spends 70% of runtime in libtorch and 21% on Cgo call -- Both are under expectation.

I removed code that calls `runtime.trace` added in https://github.com/wangkuiyi/gotorch/pull/138, because what we want is not tracing but pprof.

There is no need to change the test code to have pprof; instead, we can run the following command to get the profiling output into `cpu.prof`.

```bash
go test -cpuprofile cpu.prof -memprofile mem.prof -v -run TrainMLPUsingMNIST
```

Then, we can run `go tool pprof -pdf cpu.prof` to render `gpu.prof` into a PDF file.