### PR TITLE
Remove unnecessary goroutine in finalizer function

### DIFF
--- a/tensor.go
+++ b/tensor.go
@@ -26,12 +26,10 @@ func SetTensorFinalizer(t *unsafe.Pointer) {
 		tensorFinalizersWG.Add(1)
 	}
 	runtime.SetFinalizer(t, func(ct *unsafe.Pointer) {
-		go func() {
-			C.Tensor_Close(C.Tensor(*ct))
-			if p {
-				tensorFinalizersWG.Done()
-			}
-		}()
+		C.Tensor_Close(C.Tensor(*ct))
+		if p {
+			tensorFinalizersWG.Done()
+		}
 	})
 }
 


### PR DESCRIPTION
c.f. https://golang.org/src/runtime/mfinal.go?s=10402:10459#L306
> A single goroutine runs all finalizers for a program, sequentially.
 If a finalizer must run for a long time, it should do so by starting
 a new goroutine.

The finalized function runs in a goroutine  sequentially,  we don't need to run the  finalizer function concurrence, so I remove the `go func() ...` 

