### PR TITLE
Add a simple training loop of resnet50

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -118,6 +118,10 @@ const char *ConvTranspose2d(Tensor input, Tensor weight, Tensor bias,
 const char *BinaryCrossEntropy(Tensor input, Tensor target, Tensor weight,
                                const char *reduction, Tensor *result);
 
+const char *CrossEntropy(Tensor input, Tensor target, Tensor weight,
+                         int64_t ignore_index, const char *reduction,
+                         Tensor *result);
+
 const char *NllLoss(Tensor input, Tensor target, Tensor weight,
                     int64_t ignore_index, const char *reduction,
                     Tensor *result);

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -126,6 +126,7 @@ const char *NllLoss(Tensor input, Tensor target, Tensor weight,
                     int64_t ignore_index, const char *reduction,
                     Tensor *result);
 
+const char *FRelu(Tensor input, int8_t inplace, Tensor *result);
 const char *Linear(Tensor input, Tensor weight, Tensor bias, Tensor *result);
 
 const char *MaxPool2d(Tensor input, int64_t *kernel_data, int64_t kernel_len,

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -148,6 +148,7 @@ Optimizer Adam(double learning_rate, double beta1, double beta2,
 void Optimizer_ZeroGrad(Optimizer opt);
 void Optimizer_Step(Optimizer opt);
 void Optimizer_AddParameters(Optimizer opt, Tensor *tensors, int64_t length);
+void Optimizer_SetLR(Optimizer opt, double learning_rate);
 void Optimizer_Close(Optimizer opt);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -47,6 +47,7 @@ const char *LeakyRelu(Tensor a, double negative_slope, Tensor *result);
 const char *Tanh(Tensor a, Tensor *result);
 const char *Sigmoid(Tensor a, Tensor *result);
 const char *Add(Tensor a, Tensor other, float alpha, Tensor *result);
+const char *Add_(Tensor a, Tensor other, Tensor *result);
 const char *Flatten(Tensor a, int64_t startDim, int64_t endDim, Tensor *result);
 const char *TopK(Tensor a, int64_t k, int64_t dim, int8_t largest,
                  int8_t sorted, Tensor *values, Tensor *indices);

--- a/cgotorch/functional.cc
+++ b/cgotorch/functional.cc
@@ -95,6 +95,30 @@ const char *BinaryCrossEntropy(Tensor input, Tensor target, Tensor weight,
   }
 }
 
+const char *CrossEntropy(Tensor input, Tensor target, Tensor weight,
+                         int64_t ignore_index, const char *reduction,
+                         Tensor *result) {
+  static std::unordered_map<std::string,
+                            torch::nn::CrossEntropyLossOptions::reduction_t>
+      reduce_map = {
+          {"none", torch::kNone},
+          {"mean", torch::kMean},
+          {"sum", torch::kSum},
+      };
+  try {
+    auto output = torch::nn::functional::cross_entropy(
+        *input, *target,
+        torch::nn::functional::CrossEntropyFuncOptions()
+            .weight((weight ? *weight : torch::Tensor()))
+            .ignore_index(ignore_index)
+            .reduction(reduce_map[std::string(reduction)]));
+    *result = new at::Tensor(output);
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *NllLoss(Tensor input, Tensor target, Tensor weight,
                     int64_t ignore_index, const char *reduction,
                     Tensor *result) {

--- a/cgotorch/functional.cc
+++ b/cgotorch/functional.cc
@@ -119,6 +119,17 @@ const char *CrossEntropy(Tensor input, Tensor target, Tensor weight,
   }
 }
 
+const char *FRelu(Tensor input, int8_t inplace, Tensor *result) {
+  try {
+    auto out = torch::nn::functional::relu(
+        *input, torch::nn::functional::ReLUFuncOptions(inplace));
+    *result = new at::Tensor(out);
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *NllLoss(Tensor input, Tensor target, Tensor weight,
                     int64_t ignore_index, const char *reduction,
                     Tensor *result) {

--- a/cgotorch/optim.cc
+++ b/cgotorch/optim.cc
@@ -36,4 +36,16 @@ void Optimizer_AddParameters(Optimizer opt, Tensor* tensors, int64_t length) {
   opt->add_param_group({params});
 }
 
+void Optimizer_SetLR(Optimizer opt, double learning_rate) {
+  if (dynamic_cast<torch::optim::SGD*>(opt)) {
+    for (auto& pg : opt->param_groups()) {
+      static_cast<torch::optim::SGDOptions*>(&pg.options())->lr(learning_rate);
+    }
+  } else if (dynamic_cast<torch::optim::Adam*>(opt)) {
+    for (auto& pg : opt->param_groups()) {
+      static_cast<torch::optim::AdamOptions*>(&pg.options())->lr(learning_rate);
+    }
+  }
+}
+
 void Optimizer_Close(Optimizer opt) { delete opt; }

--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -137,6 +137,15 @@ const char *Add(Tensor a, Tensor other, float alpha, Tensor *result) {
   }
 }
 
+const char *Add_(Tensor a, Tensor other, Tensor *result) {
+  try {
+    *result = new at::Tensor(a->add_(*other));
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *Flatten(Tensor a, int64_t startDim, int64_t endDim,
                     Tensor *result) {
   try {

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -216,7 +216,7 @@ func adjustLearningRate(opt torch.Optimizer, epoch int, lr float64) {
 
 func main() {
 	batchSize := int64(16)
-	epochs := 90
+	epochs := 1000
 	lr := 0.1
 	momentum := 0.9
 	weightDecay := 1e-4

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -49,7 +49,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out = torch.Add(out, identity, 1)
+	out.AddInplace(identity)
 	out = F.Relu(out, true)
 	return out
 }
@@ -98,7 +98,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out = torch.Add(out, identity, 1)
+	out.AddInplace(identity)
 	out = F.Relu(out, true)
 	return out
 }

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 
@@ -231,19 +232,21 @@ func main() {
 
 	for epoch := 0; epoch < epochs; epoch++ {
 		model.Train(true)
+		torch.GC()
 
-		image := torch.RandN([]int64{batchSize, 3, 224, 224}, false)
+		image := torch.RandN([]int64{batchSize, 3, 224, 224}, false).To(device, torch.Float)
 		target := torch.Empty([]int64{batchSize}, false)
 		initializer.Uniform(&target, 0, 1000)
-
-		image.To(device, image.Dtype())
-		target.To(device, torch.Long)
+		target = target.To(device, torch.Long)
 
 		output := model.Forward(image)
 		loss := F.CrossEntropy(output, target, torch.Tensor{}, -100, "mean")
+
+		fmt.Printf("loss: %f\n", loss.Item())
 
 		optimizer.ZeroGrad()
 		loss.Backward()
 		optimizer.Step()
 	}
+	torch.FinishGC()
 }

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -40,7 +40,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 
 	out := b.C1.Forward(x)
 	out = b.BN1.Forward(out)
-	out = torch.Relu(out)
+	out = F.Relu(out, true)
 
 	out = b.C2.Forward(out)
 	out = b.BN2.Forward(out)
@@ -50,7 +50,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 	}
 
 	out = torch.Add(out, identity, 1)
-	out = torch.Relu(out)
+	out = F.Relu(out, true)
 	return out
 }
 
@@ -86,11 +86,11 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 	out := b.C1.Forward(x)
 
 	out = b.BN1.Forward(out)
-	out = torch.Relu(out)
+	out = F.Relu(out, true)
 
 	out = b.C2.Forward(out)
 	out = b.BN2.Forward(out)
-	out = torch.Relu(out)
+	out = F.Relu(out, true)
 
 	out = b.C3.Forward(out)
 	out = b.BN3.Forward(out)
@@ -99,7 +99,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 	}
 
 	out = torch.Add(out, identity, 1)
-	out = torch.Relu(out)
+	out = F.Relu(out, true)
 	return out
 }
 
@@ -184,7 +184,7 @@ func (r *ResnetModule) makeLayer(block reflect.Type, planes, blocks, stride int6
 func (r *ResnetModule) Forward(x torch.Tensor) torch.Tensor {
 	x = r.C1.Forward(x)
 	x = r.BN1.Forward(x)
-	x = torch.Relu(x)
+	x = F.Relu(x, true)
 	x = F.MaxPool2d(x, []int64{3, 3}, []int64{2, 2}, []int64{1, 1}, []int64{1, 1}, true)
 
 	x = r.L1.Forward(x).(torch.Tensor)

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -230,7 +230,7 @@ func main() {
 		device = torch.NewDevice("cpu")
 	}
 
-	model := Resnet18()
+	model := Resnet50()
 	model.To(device)
 
 	optimizer := torch.SGD(lr, momentum, 0, weightDecay, false)

--- a/example/resnet/resnet.py
+++ b/example/resnet/resnet.py
@@ -1,0 +1,46 @@
+import torch
+import torch.optim
+import torch.nn.functional as F
+
+import torchvision.models as models
+
+
+def adjust_learning_rate(optimizer, epoch, lr):
+    new_lr = lr * (0.1**(epoch // 30))
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = new_lr
+
+
+if __name__ == "__main__":
+    batch_size = 16
+    epochs = 90
+    lr = 0.1
+    mementum = 0.9
+    weight_decay = 1e-4
+
+    device = torch.device(
+        "cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+    model = models.resnet50().to(device)
+    optimizer = torch.optim.SGD(model.parameters(),
+                                lr,
+                                momentum=mementum,
+                                weight_decay=weight_decay)
+
+    for epoch in range(epochs):
+        adjust_learning_rate(optimizer, epoch, lr)
+
+        model.train()
+
+        image = torch.randn((batch_size, 3, 224, 224)).to(device)
+        target = torch.empty(batch_size,
+                             dtype=torch.long).random_(1000).to(device)
+
+        output = model(image)
+        loss = F.cross_entropy(output, target)
+
+        print("loss: ", loss.item())
+
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()

--- a/example/resnet/resnet.py
+++ b/example/resnet/resnet.py
@@ -13,7 +13,7 @@ def adjust_learning_rate(optimizer, epoch, lr):
 
 if __name__ == "__main__":
     batch_size = 16
-    epochs = 90
+    epochs = 1000
     lr = 0.1
     mementum = 0.9
     weight_decay = 1e-4

--- a/nn/functional/functional.go
+++ b/nn/functional/functional.go
@@ -131,6 +131,24 @@ func BinaryCrossEntropy(input, target, weight torch.Tensor,
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
 
+// CrossEntropy torch.nn.functional.cross_entropy
+func CrossEntropy(input, target, weight torch.Tensor, ignoreIndex int64,
+	reduction string) torch.Tensor {
+	var cweight, t C.Tensor
+	if weight.T != nil {
+		cweight = C.Tensor(*weight.T)
+	}
+	torch.MustNil(unsafe.Pointer(C.CrossEntropy(
+		C.Tensor(*input.T),
+		C.Tensor(*target.T),
+		cweight,
+		C.int64_t(ignoreIndex),
+		C.CString(reduction),
+		&t)))
+	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return torch.Tensor{(*unsafe.Pointer)(&t)}
+}
+
 // Linear ports torch.nn.functional.linear
 func Linear(input, weight, bias torch.Tensor) torch.Tensor {
 	var t C.Tensor

--- a/nn/functional/functional.go
+++ b/nn/functional/functional.go
@@ -149,6 +149,19 @@ func CrossEntropy(input, target, weight torch.Tensor, ignoreIndex int64,
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
 
+// Relu torch.nn.functional.relu
+func Relu(input torch.Tensor, inplace bool) torch.Tensor {
+	var t C.Tensor
+	var cInplace C.int8_t
+	if inplace {
+		cInplace = 1
+	}
+	torch.MustNil(unsafe.Pointer(C.FRelu(
+		C.Tensor(*input.T), C.int8_t(cInplace), &t)))
+	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return torch.Tensor{(*unsafe.Pointer)(&t)}
+}
+
 // Linear ports torch.nn.functional.linear
 func Linear(input, weight, bias torch.Tensor) torch.Tensor {
 	var t C.Tensor

--- a/optim.go
+++ b/optim.go
@@ -54,6 +54,11 @@ func (opt Optimizer) Step() {
 	C.Optimizer_Step(*opt.Opt)
 }
 
+// SetLR sets learning rate
+func (opt Optimizer) SetLR(lr float64) {
+	C.Optimizer_SetLR(*opt.Opt, C.double(lr))
+}
+
 // Close the optimizer
 func (opt Optimizer) Close() {
 	C.Optimizer_Close(*opt.Opt)

--- a/tensor.go
+++ b/tensor.go
@@ -320,6 +320,17 @@ func Add(a, other Tensor, alpha float32) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
+// AddInplace torch.add_
+func (a *Tensor) AddInplace(other Tensor) Tensor {
+	var t C.Tensor
+	MustNil(unsafe.Pointer(C.Add_(
+		C.Tensor(*a.T),
+		C.Tensor(*other.T),
+		&t)))
+	SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return Tensor{(*unsafe.Pointer)(&t)}
+}
+
 // Flatten torch.flatten
 func Flatten(a Tensor, startDim, endDim int64) Tensor {
 	var t C.Tensor


### PR DESCRIPTION
**Naive version**

Set batch size to 16

GoTorch GPU memory: 4016MiB
PyTorch GPU memory: 2555MiB

PyTorch uses `nn.ReLU(inplace=True)`, while GoTorch not. This needs to be optimized further.

**After adding Relu inplace**

GoTorch GPU memory: 3326MiB

**After adding Add inplace**

GoTorch GPU memory: 2942MiB