### PR TITLE
Rename Tensor.AddInplace into Tensor.AddI

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -39,6 +39,8 @@ const char *Rand(int64_t *size, int64_t length, int64_t require_grad,
 const char *Empty(int64_t *size, int64_t length, int64_t require_grad,
                   Tensor *result);
 
+const char *Equal(Tensor a, Tensor b, int64_t *result);
+
 const char *MM(Tensor a, Tensor b, Tensor *result);
 const char *Sum(Tensor a, Tensor *result);
 const char *SumByDim(Tensor a, int64_t dim, int8_t keepDim, Tensor *result);

--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -49,7 +49,7 @@ const char *LeakyRelu(Tensor a, double negative_slope, Tensor *result);
 const char *Tanh(Tensor a, Tensor *result);
 const char *Sigmoid(Tensor a, Tensor *result);
 const char *Add(Tensor a, Tensor other, float alpha, Tensor *result);
-const char *Add_(Tensor a, Tensor other, Tensor *result);
+const char *Add_(Tensor a, Tensor other, float alpha, Tensor *result);
 const char *Flatten(Tensor a, int64_t startDim, int64_t endDim, Tensor *result);
 const char *TopK(Tensor a, int64_t k, int64_t dim, int8_t largest,
                  int8_t sorted, Tensor *values, Tensor *indices);

--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -146,9 +146,9 @@ const char *Add(Tensor a, Tensor other, float alpha, Tensor *result) {
   }
 }
 
-const char *Add_(Tensor a, Tensor other, Tensor *result) {
+const char *Add_(Tensor a, Tensor other, float alpha, Tensor *result) {
   try {
-    *result = new at::Tensor(a->add_(*other));
+    *result = new at::Tensor(a->add_(*other, alpha));
     return nullptr;
   } catch (const std::exception &e) {
     return exception_str(e.what());

--- a/cgotorch/torch.cc
+++ b/cgotorch/torch.cc
@@ -64,6 +64,15 @@ const char *Empty(int64_t *size, int64_t length, int64_t require_grad,
   }
 }
 
+const char *Equal(Tensor a, Tensor b, int64_t *result) {
+  try {
+    *result = at::equal(*a, *b) ? 1 : 0;
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *MM(Tensor a, Tensor b, Tensor *result) {
   try {
     at::Tensor c = at::mm(*a, *b);

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -49,7 +49,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.אdd(identity)
+	out.Add(identity)
 	out = F.Relu(out, true)
 	return out
 }
@@ -98,7 +98,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.אdd(identity)
+	out.Add(identity)
 	out = F.Relu(out, true)
 	return out
 }

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -49,7 +49,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.Add(identity)
+	out.AddI(identity, 1)
 	out = F.Relu(out, true)
 	return out
 }
@@ -98,7 +98,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.Add(identity)
+	out.AddI(identity, 1)
 	out = F.Relu(out, true)
 	return out
 }
@@ -185,7 +185,7 @@ func (r *ResnetModule) Forward(x torch.Tensor) torch.Tensor {
 	x = r.C1.Forward(x)
 	x = r.BN1.Forward(x)
 	x = F.Relu(x, true)
-	x = F.MaxPool2d(x, []int64{3, 3}, []int64{2, 2}, []int64{1, 1}, []int64{1, 1}, true)
+	x = F.MaxPool2d(x, []int64{3, 3}, []int64{2, 2}, []int64{1, 1}, []int64{1, 1}, false)
 
 	x = r.L1.Forward(x).(torch.Tensor)
 	x = r.L2.Forward(x).(torch.Tensor)

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -49,7 +49,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.AddInplace(identity)
+	out.Add_(identity)
 	out = F.Relu(out, true)
 	return out
 }
@@ -98,7 +98,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.AddInplace(identity)
+	out.Add_(identity)
 	out = F.Relu(out, true)
 	return out
 }

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -49,7 +49,7 @@ func (b *BasicBlockModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.Add_(identity)
+	out.אdd(identity)
 	out = F.Relu(out, true)
 	return out
 }
@@ -98,7 +98,7 @@ func (b *BottleneckModule) Forward(x torch.Tensor) torch.Tensor {
 		identity = b.Downsample.Forward(x).(torch.Tensor)
 	}
 
-	out.Add_(identity)
+	out.אdd(identity)
 	out = F.Relu(out, true)
 	return out
 }

--- a/tensor.go
+++ b/tensor.go
@@ -320,8 +320,8 @@ func Add(a, other Tensor, alpha float32) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// אdd torch.add_
-func (a *Tensor) אdd(other Tensor) Tensor {
+// Add adds in-place
+func (a *Tensor) Add(other Tensor) Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Add_(
 		C.Tensor(*a.T),

--- a/tensor.go
+++ b/tensor.go
@@ -420,3 +420,10 @@ func View(a Tensor, shape []int64) Tensor {
 func To(a Tensor, device Device, dtype int8) Tensor {
 	return a.To(device, dtype)
 }
+
+// Equal compares two tensors by their content.
+func Equal(a, b Tensor) bool {
+	var r int64
+	MustNil(unsafe.Pointer(C.Equal(C.Tensor(*a.T), C.Tensor(*b.T), (*C.int64_t)(&r))))
+	return r != 0
+}

--- a/tensor.go
+++ b/tensor.go
@@ -320,12 +320,18 @@ func Add(a, other Tensor, alpha float32) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// Add adds in-place
-func (a *Tensor) Add(other Tensor) Tensor {
+// Add torch.add
+func (a *Tensor) Add(other Tensor, alpha float32) Tensor {
+	return Add(*a, other, alpha)
+}
+
+// AddI adds in-place
+func (a *Tensor) AddI(other Tensor, alpha float32) Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Add_(
 		C.Tensor(*a.T),
 		C.Tensor(*other.T),
+		C.float(alpha),
 		&t)))
 	SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return Tensor{(*unsafe.Pointer)(&t)}

--- a/tensor.go
+++ b/tensor.go
@@ -320,8 +320,8 @@ func Add(a, other Tensor, alpha float32) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// AddInplace torch.add_
-func (a *Tensor) AddInplace(other Tensor) Tensor {
+// אdd torch.add_
+func (a *Tensor) אdd(other Tensor) Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Add_(
 		C.Tensor(*a.T),

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -52,3 +52,11 @@ func TestMean(t *testing.T) {
 	z := y.Item()
 	assert.NotNil(t, z)
 }
+
+func TestAdd(t *testing.T) {
+	x := torch.RandN([]int64{2, 3}, false)
+	y := torch.RandN([]int64{2, 3}, false)
+	z := torch.Add(x, y, 1)
+	x.Add(y)
+	assert.True(t, torch.Equal(x, z))
+}

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -57,6 +57,6 @@ func TestAdd(t *testing.T) {
 	x := torch.RandN([]int64{2, 3}, false)
 	y := torch.RandN([]int64{2, 3}, false)
 	z := torch.Add(x, y, 1)
-	x.Add(y)
+	x.AddI(y, 1)
 	assert.True(t, torch.Equal(x, z))
 }


### PR DESCRIPTION
Address https://github.com/wangkuiyi/gotorch/pull/158/files#r474089268

In libtorch, there are three Add function/methods:

1. `Tensor& Tensor::Add_(Tensor)` returns the tensor itself.
1. `Tensor Tensor::Add(Tenosr)`
1. `Tensor Add(Tensor, Tensor)`

In Go, we can have

1. `func (t Tensor) AddInplace(Tensor)`
1. `func (t Tensor) Add(Tensor) Tensor`
1. `func Add(a, b Tensor) Tensor`

The only question is `AddInplace` is too long, and `Add_` is prohibitive by Go linter. How about one of the following?

- `Add∅` -- ∅ represents an empty set.
- `AddØ` -- Ø is a Norwegian letter considered the origin of ∅.
- `Add0` -- 0 is easy to type but might be misleading -- adding 0 to the current tensor?