### PR TITLE
Measure time of resnet example

### DIFF
--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math"
 	"reflect"
+	"time"
 
 	torch "github.com/wangkuiyi/gotorch"
 	"github.com/wangkuiyi/gotorch/nn"
@@ -216,7 +217,7 @@ func adjustLearningRate(opt torch.Optimizer, epoch int, lr float64) {
 
 func main() {
 	batchSize := int64(16)
-	epochs := 1000
+	epochs := 100
 	lr := 0.1
 	momentum := 0.9
 	weightDecay := 1e-4
@@ -236,6 +237,7 @@ func main() {
 	optimizer := torch.SGD(lr, momentum, 0, weightDecay, false)
 	optimizer.AddParameters(model.Parameters())
 
+	start := time.Now()
 	for epoch := 0; epoch < epochs; epoch++ {
 		adjustLearningRate(optimizer, epoch, lr)
 
@@ -258,4 +260,5 @@ func main() {
 		}
 	}
 	torch.FinishGC()
+	fmt.Println(time.Since(start).Seconds())
 }

--- a/example/resnet/resnet.py
+++ b/example/resnet/resnet.py
@@ -14,7 +14,7 @@ def adjust_learning_rate(optimizer, epoch, lr):
 
 if __name__ == "__main__":
     batch_size = 16
-    epochs = 1000
+    epochs = 100
     lr = 0.1
     mementum = 0.9
     weight_decay = 1e-4

--- a/example/resnet/resnet.py
+++ b/example/resnet/resnet.py
@@ -1,3 +1,4 @@
+import time
 import torch
 import torch.optim
 import torch.nn.functional as F
@@ -27,6 +28,7 @@ if __name__ == "__main__":
                                 momentum=mementum,
                                 weight_decay=weight_decay)
 
+    start = time.time()
     for epoch in range(epochs):
         adjust_learning_rate(optimizer, epoch, lr)
 
@@ -44,3 +46,4 @@ if __name__ == "__main__":
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
+    print(time.time() - start)


### PR DESCRIPTION
|          | 1 round    | 2 round | 3 round |
|--------------- | --------- |-------|------|
| PyTorch   |9.371349573135376 |9.357530117034912 |9.361428260803223|
| GoTorch |9.278963933 |9.278959084 |9.281217613|

GoTorch is slightly fast than PyTorch.