### PR TITLE
Move dataset packages

### DIFF
--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -7,7 +7,8 @@ import (
 	nn "github.com/wangkuiyi/gotorch/nn"
 	F "github.com/wangkuiyi/gotorch/nn/functional"
 	"github.com/wangkuiyi/gotorch/nn/initializer"
-	"github.com/wangkuiyi/gotorch/vision"
+	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
 func generator(nz int64) *nn.SequentialModule {
@@ -42,8 +43,8 @@ func discriminator() *nn.SequentialModule {
 }
 
 func main() {
-	mnist := vision.MNIST("",
-		[]vision.Transform{vision.Normalize(0.5, 0.5)})
+	mnist := datasets.MNIST("",
+		[]transforms.Transform{transforms.Normalize(0.5, 0.5)})
 
 	nz := int64(100)
 	lr := 0.0002
@@ -63,7 +64,7 @@ func main() {
 	batchSize := int64(64)
 	i := 0
 	for epoch := 0; epoch < epochs; epoch++ {
-		trainLoader := vision.NewMNISTLoader(mnist, batchSize)
+		trainLoader := datasets.NewMNISTLoader(mnist, batchSize)
 		for trainLoader.Scan() {
 			// (1) update D network
 			// train with real

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -8,7 +8,8 @@ import (
 	nn "github.com/wangkuiyi/gotorch/nn"
 	F "github.com/wangkuiyi/gotorch/nn/functional"
 	"github.com/wangkuiyi/gotorch/nn/initializer"
-	"github.com/wangkuiyi/gotorch/vision"
+	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
 type MLPMNISTNet struct {
@@ -47,8 +48,8 @@ func ExampleTrainMLPUsingMNIST() {
 
 	initializer.ManualSeed(1)
 
-	mnist := vision.MNIST("",
-		[]vision.Transform{vision.Normalize(0.1307, 0.3081)})
+	mnist := datasets.MNIST("",
+		[]transforms.Transform{transforms.Normalize(0.1307, 0.3081)})
 
 	net := NewMNISTNet()
 	net.ZeroGrad()
@@ -61,7 +62,7 @@ func ExampleTrainMLPUsingMNIST() {
 	var lastLoss float32
 	iters := 0
 	for epoch := 0; epoch < epochs; epoch++ {
-		trainLoader := vision.NewMNISTLoader(mnist, 64)
+		trainLoader := datasets.NewMNISTLoader(mnist, 64)
 		for trainLoader.Scan() {
 			batch := trainLoader.Batch()
 			data, target := batch.Data.To(device, batch.Data.Dtype()), batch.Target.To(device, batch.Target.Dtype())
@@ -104,15 +105,15 @@ func ExampleTrainMNISTSequential() {
 	net.Init(net)
 	net.ZeroGrad()
 
-	mnist := vision.MNIST("",
-		[]vision.Transform{vision.Normalize(0.1307, 0.3081)})
+	mnist := datasets.MNIST("",
+		[]transforms.Transform{transforms.Normalize(0.1307, 0.3081)})
 
 	opt := torch.SGD(0.1, 0.5, 0, 0, false)
 	opt.AddParameters(net.Parameters())
 	epochs := 1
 	startTime := time.Now()
 	for i := 0; i < epochs; i++ {
-		trainLoader := vision.NewMNISTLoader(mnist, 64)
+		trainLoader := datasets.NewMNISTLoader(mnist, 64)
 		for trainLoader.Scan() {
 			batch := trainLoader.Batch()
 			opt.ZeroGrad()

--- a/vision/datasets/download_mnist.go
+++ b/vision/datasets/download_mnist.go
@@ -1,4 +1,4 @@
-package vision
+package datasets
 
 import (
 	"compress/gzip"

--- a/vision/datasets/download_mnist_test.go
+++ b/vision/datasets/download_mnist_test.go
@@ -1,4 +1,4 @@
-package vision
+package datasets
 
 import (
 	"io/ioutil"

--- a/vision/datasets/mnist_test.go
+++ b/vision/datasets/mnist_test.go
@@ -1,4 +1,4 @@
-package vision_test
+package datasets
 
 import (
 	"os"
@@ -7,12 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wangkuiyi/gotorch"
-	"github.com/wangkuiyi/gotorch/vision"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
 func ExampleMNIST() {
-	dataset := vision.MNIST("", []vision.Transform{vision.Normalize(0.1307, 0.3081)})
-	trainLoader := vision.NewMNISTLoader(dataset, 8)
+	dataset := MNIST("", []transforms.Transform{transforms.Normalize(0.1307, 0.3081)})
+	trainLoader := NewMNISTLoader(dataset, 8)
 	for trainLoader.Scan() {
 		_ = trainLoader.Batch()
 	}
@@ -24,7 +24,7 @@ func ExampleMNIST() {
 
 func TestNoPanicMNIST(t *testing.T) {
 	assert.NotPanics(t, func() {
-		vision.MNIST(path.Join(os.TempDir(), "not_yet_exists"),
-			[]vision.Transform{})
+		MNIST(path.Join(os.TempDir(), "not_yet_exists"),
+			[]transforms.Transform{})
 	})
 }

--- a/vision/transforms/transforms.go
+++ b/vision/transforms/transforms.go
@@ -1,9 +1,12 @@
-package vision
+package transforms
+
+// Transform interface
+type Transform interface{}
 
 // NormalizeTransformer corresponds to torchvision.transforms.html#Normalize. It
 // implements Go interface gotorch/data.Transform.
 type NormalizeTransformer struct {
-	mean, stddev float64
+	Mean, Stddev float64
 }
 
 // Normalize returns normalize transformer


### PR DESCRIPTION
Move dataset functions under `vision/datasets` package and move transform structs to `vision/transforms`, make the API similar to https://github.com/pytorch/examples/blob/4b119d735b802453479d739bf823f3f7d8d5d422/mnist/main.py#L7