### PR TITLE
Add variadic and NewTensor

### DIFF
--- a/dtype.go
+++ b/dtype.go
@@ -1,36 +1,110 @@
 package gotorch
 
+import (
+	"log"
+	"reflect"
+	"unsafe"
+
+	"github.com/wangkuiyi/gotorch/variadic"
+)
+
 const (
-	// Byte type 0
+	// Invalid Dtype
+	Invalid = -1
+	// Byte Dtype 0
 	Byte int8 = iota
-	// Char type 1
+	// Char Dtype 1
 	Char
-	// Short type 2
+	// Short Dtype 2
 	Short
-	// Int type 3
+	// Int Dtype 3
 	Int
-	// Long type 4
+	// Long Dtype 4
 	Long
-	// Half type 5
+	// Half Dtype 5
 	Half
-	// Float type 6
+	// Float Dtype 6
 	Float
-	// Double type 7
+	// Double Dtype 7
 	Double
-	// ComplexHalf type 8
+	// ComplexHalf Dtype 8
 	ComplexHalf
-	// ComplexFloat type 9
+	// ComplexFloat Dtype 9
 	ComplexFloat
-	// ComplexDouble type 10
+	// ComplexDouble Dtype 10
 	ComplexDouble
-	// Bool type 11
+	// Bool Dtype 11
 	Bool
-	// QInt8 type 12
+	// QInt8 Dtype 12
 	QInt8
-	// QUInt8 type 13
+	// QUInt8 Dtype 13
 	QUInt8
-	// QInt32 type 14
+	// QInt32 Dtype 14
 	QInt32
-	// BFloat16 type 15
+	// BFloat16 Dtype 15
 	BFloat16
+)
+
+// NewTensor creates a tensor from a Go slice.  We use variadic parameters of
+// type map[string]interface{} to mimic named variadic parameters.
+func NewTensor(data interface{}, options ...map[string]interface{}) Tensor {
+	t := reflect.TypeOf(data)
+	if t.Kind() != reflect.Slice {
+		log.Panicf("NewTensor requires a slice; got a %v", t.Kind())
+	}
+
+	// TODO(wangkuiyi): Add Tensor.{SetRequiresGrad,RequiresGrad}.
+	// requireGrad := variadic.Get(options, "requires_grad").(bool)
+
+	shape, kind := sliceShapeAndElemKind(data)
+	dtype := tensorElemDType(options, kind)
+
+	sliceAddr := unsafe.Pointer(&data)
+	dataAddr := *(*uintptr)(sliceAddr)
+	return FromBlob(unsafe.Pointer(dataAddr), dtype, shape)
+}
+
+func sliceShapeAndElemKind(data interface{}) ([]int64, reflect.Kind) {
+	var r []int64
+	v := reflect.ValueOf(data)
+	for {
+		k := v.Type().Kind()
+		if k != reflect.Slice {
+			return r, k
+		}
+		r = append(r, int64(v.Len()))
+		v = v.Index(0)
+	}
+	return nil, reflect.Invalid
+}
+
+func tensorElemDType(options []map[string]interface{}, k reflect.Kind) int8 {
+	// If the user specified the DType explicitly, it overrides the one
+	// derived from Go type.
+	//
+	// TODO(wangkuiyi): Check the size of the specified Dtype matches that
+	// of the Go element type.
+	if dtype, ok := variadic.Lookup(options, "dtype"); ok {
+		return dtype.(int8)
+	}
+
+	dtype, ok := goTypeToTorch[k]
+	if !ok {
+		return Invalid
+	}
+	return dtype
+
+}
+
+var (
+	goTypeToTorch = map[reflect.Kind]int8{
+		reflect.Bool:      Bool,
+		reflect.Int:       Int,
+		reflect.Int8:      Byte,
+		reflect.Int16:     Half,
+		reflect.Uint16:    Half,
+		reflect.Float32:   Float,
+		reflect.Float64:   Double,
+		reflect.Complex64: ComplexDouble,
+	}
 )

--- a/dtype.go
+++ b/dtype.go
@@ -80,13 +80,13 @@ func sliceShapeAndElemKind(data interface{}) ([]int64, reflect.Kind) {
 	return nil, reflect.Invalid
 }
 
-func tensorElemDType(options []map[string]interface{}, k reflect.Kind) int8 {
+func tensorElemDType(opts []map[string]interface{}, k reflect.Kind) int8 {
 	// The user specified DType, if there is any, overrides the one derived
 	// from Go reflection.
 	//
 	// TODO(wangkuiyi): Check the size of the specified Dtype matches that
 	// of the Go element type.
-	if dtype, ok := variadic.Lookup(options, "dtype"); ok {
+	if dtype, ok := variadic.Lookup(opts, "dtype"); ok {
 		return dtype.(int8)
 	}
 	dtype, ok := goTypeToTorch[k]

--- a/dtype.go
+++ b/dtype.go
@@ -1,12 +1,10 @@
 package gotorch
 
 import (
-	"fmt"
 	"log"
 	"reflect"
 	"unsafe"
 
-	"github.com/mattn/go-pointer"
 	"github.com/wangkuiyi/gotorch/variadic"
 )
 
@@ -60,13 +58,12 @@ func NewTensor(data interface{}, options ...map[string]interface{}) Tensor {
 
 	shape, kind := sliceShapeAndElemKind(data)
 	dtype := tensorElemDType(options, kind)
-
-	f := flattenDeep(data)
-	fmt.Println(f)
+	if dtype == Invalid {
+		log.Panicf("Unrecognized element kind %v", kind)
+	}
+	f := flattenSlice(data, kind)
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&f))
-	cptr := pointer.Save(unsafe.Pointer(hdr.Data))
-	defer pointer.Unref(cptr)
-	return FromBlob(cptr, dtype, shape)
+	return FromBlob(unsafe.Pointer(hdr.Data), dtype, shape)
 }
 
 func sliceShapeAndElemKind(data interface{}) ([]int64, reflect.Kind) {
@@ -84,55 +81,141 @@ func sliceShapeAndElemKind(data interface{}) ([]int64, reflect.Kind) {
 }
 
 func tensorElemDType(options []map[string]interface{}, k reflect.Kind) int8 {
-	// If the user specified the DType explicitly, it overrides the one
-	// derived from Go type.
+	// The user specified DType, if there is any, overrides the one derived
+	// from Go reflection.
 	//
 	// TODO(wangkuiyi): Check the size of the specified Dtype matches that
 	// of the Go element type.
 	if dtype, ok := variadic.Lookup(options, "dtype"); ok {
 		return dtype.(int8)
 	}
-
 	dtype, ok := goTypeToTorch[k]
 	if !ok {
-		return Invalid
+		dtype = Invalid
 	}
 	return dtype
-
 }
 
 var (
 	goTypeToTorch = map[reflect.Kind]int8{
-		reflect.Bool:      Bool,
-		reflect.Int:       Int,
-		reflect.Int8:      Byte,
-		reflect.Int16:     Half,
-		reflect.Uint16:    Half,
-		reflect.Float32:   Float,
-		reflect.Float64:   Double,
-		reflect.Complex64: ComplexDouble,
+		reflect.Bool:    Bool,
+		reflect.Int:     Int,
+		reflect.Int8:    Byte,
+		reflect.Uint16:  Half,
+		reflect.Float32: Float,
+		reflect.Float64: Double,
 	}
 )
 
 // https://medium.com/@the1mills/flattening-arrays-slices-with-golang-c796905debbe
-// We need to flatten a slice of slice of something into a one-dimensional slice
-// so to pass to FromBlob.
-func flattenDeep(args interface{}) []interface{} {
-	return flattenDeepRecur(nil, reflect.ValueOf(args))
+// provides a way to flatten any recursive slices into []interface{}.  However,
+// we cannot reuse this solution here, because libtorch wants
+// []float32/float64/..., instead of []interface{}.  Without type template as
+// that in C++, we have to write the following Go code repeatedly.
+func flattenSlice(slc interface{}, kind reflect.Kind) unsafe.Pointer {
+	switch kind {
+	case reflect.Bool:
+		f := flattenSliceBool(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	case reflect.Int:
+		f := flattenSliceInt(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	case reflect.Int8:
+		f := flattenSliceInt8(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	case reflect.Uint16:
+		f := flattenSliceUint16(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	case reflect.Float32:
+		f := flattenSliceFloat32(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	case reflect.Float64:
+		f := flattenSliceFloat64(nil, reflect.ValueOf(slc))
+		return unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&f)).Data)
+	}
+	return nil
 }
 
-func flattenDeepRecur(args []interface{}, v reflect.Value) []interface{} {
+func flattenSliceFloat32(args []float32, v reflect.Value) []float32 {
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
-
 	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
 		for i := 0; i < v.Len(); i++ {
-			args = flattenDeepRecur(args, v.Index(i))
+			args = flattenSliceFloat32(args, v.Index(i))
 		}
 	} else {
-		args = append(args, v.Interface())
+		args = append(args, float32(v.Float()))
 	}
+	return args
+}
 
+func flattenSliceFloat64(args []float64, v reflect.Value) []float64 {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flattenSliceFloat64(args, v.Index(i))
+		}
+	} else {
+		args = append(args, v.Float())
+	}
+	return args
+}
+
+func flattenSliceUint16(args []uint16, v reflect.Value) []uint16 {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flattenSliceUint16(args, v.Index(i))
+		}
+	} else {
+		args = append(args, uint16(v.Uint()))
+	}
+	return args
+}
+
+func flattenSliceBool(args []bool, v reflect.Value) []bool {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flattenSliceBool(args, v.Index(i))
+		}
+	} else {
+		args = append(args, v.Bool())
+	}
+	return args
+}
+
+func flattenSliceInt(args []int, v reflect.Value) []int {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flattenSliceInt(args, v.Index(i))
+		}
+	} else {
+		args = append(args, int(v.Int()))
+	}
+	return args
+}
+
+func flattenSliceInt8(args []int8, v reflect.Value) []int8 {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Array || v.Kind() == reflect.Slice {
+		for i := 0; i < v.Len(); i++ {
+			args = flattenSliceInt8(args, v.Index(i))
+		}
+	} else {
+		args = append(args, int8(v.Int()))
+	}
 	return args
 }

--- a/dtype_test.go
+++ b/dtype_test.go
@@ -30,7 +30,7 @@ func TestSliceShapeAndElemKind(t *testing.T) {
 
 func TestTensorElemDType(t *testing.T) {
 	{
-		data := []int16{1, 2, 3}
+		data := []uint16{1, 2, 3}
 		shape, kind := sliceShapeAndElemKind(data)
 		assert.Equal(t, []int64{3}, shape)
 
@@ -56,18 +56,21 @@ func TestNewTensor(t *testing.T) {
 		a := NewTensor([][]float32{{1.0, 1.1, 1.2}, {2, 3, 4}})
 		assert.Equal(t, []int64{2, 3}, a.Shape())
 		assert.Equal(t, Float, a.Dtype())
-		t.Log(a.String())
 	}
-	// {
-	// 	a := NewTensor([]int16{1, 2, 3},
-	// 		map[string]interface{}{
-	// 			"require_grad": true, "dtype": Half})
-	// 	assert.Equal(t, []int64{3}, a.Shape())
-	// 	assert.Equal(t, Half, a.Dtype())
-	// }
-	// {
-	// 	a := NewTensor([]int16{1, 2, 3})
-	// 	assert.Equal(t, []int64{3}, a.Shape())
-	// 	assert.Equal(t, Half, a.Dtype())
-	// }
+	{
+		a := NewTensor([][]uint16{{1, 2}, {3, 4}})
+		assert.Equal(t, []int64{2, 2}, a.Shape())
+		assert.Equal(t, Half, a.Dtype())
+	}
+	{
+		a := NewTensor([]int8{1, 2, 3})
+		assert.Equal(t, []int64{3}, a.Shape())
+		assert.Equal(t, Byte, a.Dtype())
+	}
+	{
+		assert.Panics(t, func() {
+			// int16 cannot be converted into PyTorch type
+			NewTensor([][]int16{{1, 2}, {3, 4}})
+		})
+	}
 }

--- a/dtype_test.go
+++ b/dtype_test.go
@@ -74,3 +74,42 @@ func TestNewTensor(t *testing.T) {
 		})
 	}
 }
+
+func TestFlattenSlice(t *testing.T) {
+	{
+		d := [][]float32{{1, 2, 3}, {4, 5, 6}}
+		f := flattenSliceFloat32(nil, reflect.ValueOf(d))
+		assert.Equal(t, 6, len(f))
+		assert.Equal(t, []float32{1, 2, 3, 4, 5, 6}, f)
+	}
+	{
+		d := [][]float64{{1, 2}, {3, 4}, {5, 6}}
+		f := flattenSliceFloat64(nil, reflect.ValueOf(d))
+		assert.Equal(t, 6, len(f))
+		assert.Equal(t, []float64{1, 2, 3, 4, 5, 6}, f)
+	}
+	{
+		d := [][]bool{{true, false}, {false, true}}
+		f := flattenSliceBool(nil, reflect.ValueOf(d))
+		assert.Equal(t, 4, len(f))
+		assert.Equal(t, []bool{true, false, false, true}, f)
+	}
+	{
+		d := []int{1, 2}
+		f := flattenSliceInt(nil, reflect.ValueOf(d))
+		assert.Equal(t, 2, len(f))
+		assert.Equal(t, []int{1, 2}, f)
+	}
+	{
+		d := [][]uint16{{1, 2}, {3, 4}}
+		f := flattenSliceUint16(nil, reflect.ValueOf(d))
+		assert.Equal(t, 4, len(f))
+		assert.Equal(t, []uint16{1, 2, 3, 4}, f)
+	}
+	{
+		d := [][]int8{{1, 2, 3}, {4, 5, 6}}
+		f := flattenSliceInt8(nil, reflect.ValueOf(d))
+		assert.Equal(t, 6, len(f))
+		assert.Equal(t, []int8{1, 2, 3, 4, 5, 6}, f)
+	}
+}

--- a/dtype_test.go
+++ b/dtype_test.go
@@ -1,0 +1,64 @@
+package gotorch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSliceShapeAndElemKind(t *testing.T) {
+	{
+		data := [][]float64{{1, 2}, {3, 4}, {5, 6}}
+		shape, kind := sliceShapeAndElemKind(data)
+		assert.Equal(t, []int64{3, 2}, shape)
+		assert.Equal(t, reflect.Float64, kind)
+	}
+	{
+		data := [][]float32{{1, 2}}
+		shape, kind := sliceShapeAndElemKind(data)
+		assert.Equal(t, []int64{1, 2}, shape)
+		assert.Equal(t, reflect.Float32, kind)
+	}
+	{
+		data := int32(1)
+		shape, kind := sliceShapeAndElemKind(data)
+		assert.Equal(t, 0, len(shape))
+		assert.Equal(t, reflect.Int32, kind)
+	}
+}
+
+func TestTensorElemDType(t *testing.T) {
+	data := []int16{1, 2, 3}
+	shape, kind := sliceShapeAndElemKind(data)
+	assert.Equal(t, []int64{3}, shape)
+	{
+		dtype := tensorElemDType(
+			[]map[string]interface{}{{"dtype": Bool}}, kind)
+		assert.Equal(t, Bool, dtype) // Half overrides int16
+	}
+	{
+		dtype := tensorElemDType(nil, kind)
+		assert.Equal(t, Half, dtype) // Deriving Half from int16
+	}
+}
+
+func TestNewTensor(t *testing.T) {
+	{
+		a := NewTensor([]float32{1, 2, 3})
+		assert.Equal(t, []int64{3}, a.Shape())
+		assert.Equal(t, Float, a.Dtype())
+	}
+	{
+		a := NewTensor([]int16{1, 2, 3},
+			map[string]interface{}{
+				"require_grad": true, "dtype": Half})
+		assert.Equal(t, []int64{3}, a.Shape())
+		assert.Equal(t, Half, a.Dtype())
+	}
+	{
+		a := NewTensor([]int16{1, 2, 3})
+		assert.Equal(t, []int64{3}, a.Shape())
+		assert.Equal(t, Half, a.Dtype())
+	}
+}

--- a/dtype_test.go
+++ b/dtype_test.go
@@ -29,36 +29,45 @@ func TestSliceShapeAndElemKind(t *testing.T) {
 }
 
 func TestTensorElemDType(t *testing.T) {
-	data := []int16{1, 2, 3}
-	shape, kind := sliceShapeAndElemKind(data)
-	assert.Equal(t, []int64{3}, shape)
 	{
+		data := []int16{1, 2, 3}
+		shape, kind := sliceShapeAndElemKind(data)
+		assert.Equal(t, []int64{3}, shape)
+
 		dtype := tensorElemDType(
 			[]map[string]interface{}{{"dtype": Bool}}, kind)
 		assert.Equal(t, Bool, dtype) // Half overrides int16
+
+		dtype = tensorElemDType(nil, kind)
+		assert.Equal(t, Half, dtype) // Deriving Half from int16
 	}
 	{
+		data := []float32{1, 2, 3}
+		shape, kind := sliceShapeAndElemKind(data)
+		assert.Equal(t, []int64{3}, shape)
+
 		dtype := tensorElemDType(nil, kind)
-		assert.Equal(t, Half, dtype) // Deriving Half from int16
+		assert.Equal(t, Float, dtype)
 	}
 }
 
 func TestNewTensor(t *testing.T) {
 	{
-		a := NewTensor([]float32{1, 2, 3})
-		assert.Equal(t, []int64{3}, a.Shape())
+		a := NewTensor([][]float32{{1.0, 1.1, 1.2}, {2, 3, 4}})
+		assert.Equal(t, []int64{2, 3}, a.Shape())
 		assert.Equal(t, Float, a.Dtype())
+		t.Log(a.String())
 	}
-	{
-		a := NewTensor([]int16{1, 2, 3},
-			map[string]interface{}{
-				"require_grad": true, "dtype": Half})
-		assert.Equal(t, []int64{3}, a.Shape())
-		assert.Equal(t, Half, a.Dtype())
-	}
-	{
-		a := NewTensor([]int16{1, 2, 3})
-		assert.Equal(t, []int64{3}, a.Shape())
-		assert.Equal(t, Half, a.Dtype())
-	}
+	// {
+	// 	a := NewTensor([]int16{1, 2, 3},
+	// 		map[string]interface{}{
+	// 			"require_grad": true, "dtype": Half})
+	// 	assert.Equal(t, []int64{3}, a.Shape())
+	// 	assert.Equal(t, Half, a.Dtype())
+	// }
+	// {
+	// 	a := NewTensor([]int16{1, 2, 3})
+	// 	assert.Equal(t, []int64{3}, a.Shape())
+	// 	assert.Equal(t, Half, a.Dtype())
+	// }
 }

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -76,8 +76,7 @@ func TestFromBlob(t *testing.T) {
 }
 
 func TestTensorString(t *testing.T) {
-	data := [2][3]float32{{1.0, 1.1, 1.2}, {2, 3, 4}}
-	out := torch.FromBlob(unsafe.Pointer(&data), torch.Float, []int64{2, 3})
+	out := torch.NewTensor([][]float32{{1.0, 1.1, 1.2}, {2, 3, 4}})
 	g := ` 1.0000  1.1000  1.2000
  2.0000  3.0000  4.0000
 [ CPUFloatType{2,3} ]`

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -76,7 +76,8 @@ func TestFromBlob(t *testing.T) {
 }
 
 func TestTensorString(t *testing.T) {
-	out := torch.NewTensor([][]float32{{1.0, 1.1, 1.2}, {2, 3, 4}})
+	data := [2][3]float32{{1.0, 1.1, 1.2}, {2, 3, 4}}
+	out := torch.FromBlob(unsafe.Pointer(&data), torch.Float, []int64{2, 3})
 	g := ` 1.0000  1.1000  1.2000
  2.0000  3.0000  4.0000
 [ CPUFloatType{2,3} ]`

--- a/variadic/variadic.go
+++ b/variadic/variadic.go
@@ -1,0 +1,27 @@
+package variadic
+
+// Has returns if key is specified in opts.
+func Has(opts []map[string]interface{}, key string) bool {
+	if len(opts) == 0 {
+		return false
+	}
+	_, ok := opts[0][key]
+	return ok
+}
+
+// Get returns the option specified in opts with key, or nil.
+func Get(opts []map[string]interface{}, key string) interface{} {
+	if len(opts) == 0 {
+		return nil
+	}
+	return opts[0][key]
+}
+
+// Lookup returns the value and its existence of key.
+func Lookup(opts []map[string]interface{}, key string) (interface{}, bool) {
+	if len(opts) == 0 {
+		return nil, false
+	}
+	v, ok := opts[0][key]
+	return v, ok
+}

--- a/variadic/variadic_test.go
+++ b/variadic/variadic_test.go
@@ -1,0 +1,41 @@
+package variadic_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wangkuiyi/gotorch/variadic"
+)
+
+func TestHas(t *testing.T) {
+	assert.True(t, variadic.Has(opts, "dtype"))
+	assert.True(t, variadic.Has(opts, "requires_grad"))
+	assert.False(t, variadic.Has(opts, "RequiresGrad"))
+}
+
+func TestGet(t *testing.T) {
+	assert.Equal(t, 111, variadic.Get(opts, "dtype"))
+	assert.Equal(t, false, variadic.Get(opts, "requires_grad"))
+	assert.Equal(t, nil, variadic.Get(opts, "RequiresGrad"))
+}
+
+func TestLookup(t *testing.T) {
+	v, ok := variadic.Lookup(opts, "dtype")
+	assert.Equal(t, 111, v)
+	assert.True(t, ok)
+
+	v, ok = variadic.Lookup(opts, "requires_grad")
+	assert.Equal(t, false, v)
+	assert.True(t, ok)
+
+	v, ok = variadic.Lookup(opts, "RequiresGrad")
+	assert.Equal(t, nil, v)
+	assert.False(t, ok)
+}
+
+var (
+	opts = []map[string]interface{}{{
+		"dtype":         111,
+		"requires_grad": false,
+	}}
+)


### PR DESCRIPTION
This PR allows users to write the following line to define a 2x3 tensor of type `torch::Float`.

```go
t := gotorch.NewTensor([][]float32{ {1, 2, 3}, {4, 5, 6}}
```

It also supports Byte, Int, Float, Double, Half.

This feature is more complicated than I imagined.

1. We need to flatten Go slides, for example, `[][]float32`, into one-dimensional one, `[]float`, before passing `reflect.SliceHeader.Data` to `C.FromBlob`.

1. We cannot use Go reflection to write a single function to flatten all element types because if we do so, we will make the function returns `[]interface{}`, which, `FromBlob` cannot accept.