### PR TITLE
move ImageNet dataloader to vision package

### DIFF
--- a/vision/datasets/imagenet_test.go
+++ b/vision/datasets/imagenet_test.go
@@ -1,4 +1,4 @@
-package imagenet_test
+package datasets_test
 
 import (
 	"bytes"
@@ -7,21 +7,21 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wangkuiyi/gotorch/example/resnet/imagenet"
+	"github.com/wangkuiyi/gotorch/vision/datasets"
 )
 
-func TestDataloader(t *testing.T) {
+func TestImgNetLoader(t *testing.T) {
 	var tgz1, tgz2 bytes.Buffer
 	w := io.MultiWriter(&tgz1, &tgz2)
 	generateColorData(w)
-	vocab, err := imagenet.BuildLabelVocabulary(&tgz1)
+	vocab, err := datasets.BuildLabelVocabulary(&tgz1)
 	assert.NoError(t, err)
 
-	loader, err := imagenet.NewDataLoader(&tgz2, vocab, 2)
+	loader, err := datasets.ImageNet(&tgz2, vocab, 2)
 	assert.NoError(t, err)
 
 	for loader.Scan() {
-		data, label := loader.Minibatch()
+		data, label := loader.Minibatch().Data, loader.Minibatch().Target
 		assert.Equal(t, []int64{2, 469, 387, 3}, data.Shape())
 		assert.Equal(t, []int64{2, 1}, label.Shape())
 	}
@@ -31,14 +31,14 @@ func TestToTensor(t *testing.T) {
 	{
 		// image to Tensor
 		blue := color.RGBA{0, 0, 255, 255}
-		m := imagenet.SynthesizeImage(4, 4, blue)
-		out, err := imagenet.ToTensor(m)
+		m := datasets.SynthesizeImage(4, 4, blue)
+		out, err := datasets.ToTensor(m)
 		assert.NoError(t, err)
 		assert.Equal(t, out.Shape(), []int64{4, 4, 3})
 	}
 	{
 		// int to Tensor
-		out, err := imagenet.ToTensor(10)
+		out, err := datasets.ToTensor(10)
 		assert.NoError(t, err)
 		assert.Equal(t, out.Shape(), []int64{1})
 	}

--- a/vision/datasets/synthesizer.go
+++ b/vision/datasets/synthesizer.go
@@ -1,4 +1,4 @@
-package imagenet
+package datasets
 
 import (
 	"archive/tar"

--- a/vision/datasets/synthesizer_test.go
+++ b/vision/datasets/synthesizer_test.go
@@ -1,4 +1,4 @@
-package imagenet_test
+package datasets_test
 
 import (
 	"archive/tar"
@@ -9,11 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wangkuiyi/gotorch/example/resnet/imagenet"
+	"github.com/wangkuiyi/gotorch/vision/datasets"
 )
 
 func generateColorData(w io.Writer) []string {
-	s := imagenet.NewSynthesizer(w)
+	s := datasets.NewSynthesizer(w)
 	defer s.Close()
 	colors := []color.Color{
 		color.RGBA{0, 0, 255, 255},


### PR DESCRIPTION
keep the same folder architecture with Pytorch vision.
