### PR TITLE
Refactor transforms function to be with the GoTorch Transformer pattern

### DIFF
--- a/vision/datasets/imagenet.go
+++ b/vision/datasets/imagenet.go
@@ -54,7 +54,7 @@ func ImageNet(reader io.Reader, vocab map[string]int, trans *transforms.ComposeT
 }
 
 // Minibatch returns a minibash with data and label Tensor
-func (p *ImageNetLoader) Minibatch() Batch {
+func (p *ImageNetLoader) Minibatch() (torch.Tensor, torch.Tensor) {
 	// TODO(yancey1989): execute transform function sequentially to transfrom the sample
 	// data to Tensors.
 	dataArray := []torch.Tensor{}
@@ -65,7 +65,7 @@ func (p *ImageNetLoader) Minibatch() Batch {
 		dataArray = append(dataArray, data.(torch.Tensor))
 		labelArray = append(labelArray, label)
 	}
-	return Batch{torch.Stack(dataArray, 0), torch.Stack(labelArray, 0)}
+	return torch.Stack(dataArray, 0), torch.Stack(labelArray, 0)
 }
 
 func (p *ImageNetLoader) nextSamples() error {

--- a/vision/datasets/imagenet_test.go
+++ b/vision/datasets/imagenet_test.go
@@ -21,7 +21,7 @@ func TestImgNetLoader(t *testing.T) {
 	assert.NoError(t, err)
 
 	for loader.Scan() {
-		data, label := loader.Minibatch().Data, loader.Minibatch().Target
+		data, label := loader.Minibatch()
 		assert.Equal(t, []int64{2, 224, 224, 3}, data.Shape())
 		assert.Equal(t, []int64{2, 1}, label.Shape())
 	}

--- a/vision/datasets/imagenet_test.go
+++ b/vision/datasets/imagenet_test.go
@@ -2,12 +2,12 @@ package datasets_test
 
 import (
 	"bytes"
-	"image/color"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
 func TestImgNetLoader(t *testing.T) {
@@ -16,30 +16,13 @@ func TestImgNetLoader(t *testing.T) {
 	generateColorData(w)
 	vocab, err := datasets.BuildLabelVocabulary(&tgz1)
 	assert.NoError(t, err)
-
-	loader, err := datasets.ImageNet(&tgz2, vocab, 2)
+	trans := transforms.Compose(transforms.RandomCrop(224, 224), transforms.RandomFlip(), transforms.ToTensor())
+	loader, err := datasets.ImageNet(&tgz2, vocab, trans, 2)
 	assert.NoError(t, err)
 
 	for loader.Scan() {
 		data, label := loader.Minibatch().Data, loader.Minibatch().Target
-		assert.Equal(t, []int64{2, 469, 387, 3}, data.Shape())
+		assert.Equal(t, []int64{2, 224, 224, 3}, data.Shape())
 		assert.Equal(t, []int64{2, 1}, label.Shape())
-	}
-}
-
-func TestToTensor(t *testing.T) {
-	{
-		// image to Tensor
-		blue := color.RGBA{0, 0, 255, 255}
-		m := datasets.SynthesizeImage(4, 4, blue)
-		out, err := datasets.ToTensor(m)
-		assert.NoError(t, err)
-		assert.Equal(t, out.Shape(), []int64{4, 4, 3})
-	}
-	{
-		// int to Tensor
-		out, err := datasets.ToTensor(10)
-		assert.NoError(t, err)
-		assert.Equal(t, out.Shape(), []int64{1})
 	}
 }

--- a/vision/transforms/center_crop.go
+++ b/vision/transforms/center_crop.go
@@ -18,15 +18,11 @@ func CenterCrop(width, height int) *CenterCropTransformer {
 }
 
 // Run execute the center crop function and returns the cropped image object.
-func (t *CenterCropTransformer) Run(input interface{}) (interface{}, error) {
-	i, ok := input.(image.Image)
-	if !ok {
-		return nil, fmt.Errorf("input should be image.Image type")
-	}
-	if t.width > i.Bounds().Max.X || t.height > i.Bounds().Max.Y {
-		return nil, fmt.Errorf("crop size (%d, %d) should be within image size (%d, %d)",
-			t.width, t.height, i.Bounds().Max.X, i.Bounds().Max.Y)
+func (t *CenterCropTransformer) Run(input image.Image) image.Image {
+	if t.width > input.Bounds().Max.X || t.height > input.Bounds().Max.Y {
+		panic(fmt.Sprintf("crop size (%d, %d) should be within image size (%d, %d)",
+			t.width, t.height, input.Bounds().Max.X, input.Bounds().Max.Y))
 	}
 
-	return imaging.CropCenter(i, t.width, t.height), nil
+	return imaging.CropCenter(input, t.width, t.height)
 }

--- a/vision/transforms/center_crop_test.go
+++ b/vision/transforms/center_crop_test.go
@@ -11,15 +11,13 @@ func TestCenterCrop(t *testing.T) {
 	a := assert.New(t)
 
 	i := generateRandImage(image.Rect(0, 0, 200, 200))
-	trans := CenterCrop(50, 250)
-	_, err := trans.Run(100)
-	a.Error(err)
-	_, err = trans.Run(i)
-	a.Error(err)
+	a.Panics(func() {
+		trans := CenterCrop(50, 250)
+		trans.Run(i)
+	})
 
-	trans = CenterCrop(50, 50)
-	o, err := trans.Run(i)
-	a.NoError(err)
+	trans := CenterCrop(50, 50)
+	o := trans.Run(i)
 	outImage := o.(image.Image)
 	a.Equal(50, outImage.Bounds().Max.X)
 	startX := (200 - 50) / 2

--- a/vision/transforms/random_crop.go
+++ b/vision/transforms/random_crop.go
@@ -20,23 +20,19 @@ func RandomCrop(width, height int) *RandomCropTransformer {
 }
 
 // Run execute the random crop function and returns the cropped image object.
-func (t *RandomCropTransformer) Run(input interface{}) (interface{}, error) {
-	i, ok := input.(image.Image)
-	if !ok {
-		return nil, fmt.Errorf("input should be image.Image type")
-	}
-	if t.width > i.Bounds().Max.X || t.height > i.Bounds().Max.Y {
-		return nil, fmt.Errorf("crop size (%d, %d) should be within image size (%d, %d)",
-			t.width, t.height, i.Bounds().Max.X, i.Bounds().Max.Y)
+func (t *RandomCropTransformer) Run(input image.Image) image.Image {
+	if t.width > input.Bounds().Max.X || t.height > input.Bounds().Max.Y {
+		panic(fmt.Sprintf("crop size (%d, %d) should be within image size (%d, %d)",
+			t.width, t.height, input.Bounds().Max.X, input.Bounds().Max.Y))
 	}
 	rand.Seed(time.Now().UnixNano())
-	x := rand.Intn(i.Bounds().Max.X - t.width)
-	y := rand.Intn(i.Bounds().Max.Y - t.height)
+	x := rand.Intn(input.Bounds().Max.X - t.width)
+	y := rand.Intn(input.Bounds().Max.Y - t.height)
 
 	rect := image.Rectangle{
 		Min: image.Point{X: x, Y: y},
 		Max: image.Point{X: x + t.width, Y: y + t.height},
 	}
-	croped := imaging.Crop(i, rect)
-	return croped, nil
+	croped := imaging.Crop(input, rect)
+	return croped
 }

--- a/vision/transforms/random_crop_test.go
+++ b/vision/transforms/random_crop_test.go
@@ -12,24 +12,16 @@ func TestRandomCrop(t *testing.T) {
 
 	m := generateRandImage(image.Rect(0, 0, 200, 200))
 	trans := RandomCrop(100, 100)
-	cropped, err := trans.Run(m)
-	a.NoError(err)
-	i, ok := cropped.(image.Image)
-	if !ok {
-		a.Fail("returned image is not of type image.Image")
-	}
-	a.Equal(100, i.Bounds().Max.X)
-	a.Equal(100, i.Bounds().Max.Y)
+	cropped := trans.Run(m)
+	a.Equal(100, cropped.Bounds().Max.X)
+	a.Equal(100, cropped.Bounds().Max.Y)
 }
 
-func TestRandomCropSizeError(t *testing.T) {
+func TestRandomCropSizePanics(t *testing.T) {
 	a := assert.New(t)
-
 	m := generateRandImage(image.Rect(0, 0, 200, 200))
 	trans := RandomCrop(300, 300)
-
-	_, err := trans.Run("some string")
-	a.Error(err)
-	_, err = trans.Run(m)
-	a.Error(err)
+	a.Panics(func() {
+		trans.Run(m)
+	})
 }

--- a/vision/transforms/random_flip.go
+++ b/vision/transforms/random_flip.go
@@ -1,7 +1,6 @@
 package transforms
 
 import (
-	"fmt"
 	"image"
 	"math/rand"
 	"time"
@@ -19,14 +18,10 @@ func RandomFlip() *RandomFlipTransformer {
 }
 
 // Run execute the random flip function and returns the flipped image object.
-func (t *RandomFlipTransformer) Run(input interface{}) (interface{}, error) {
-	i, ok := input.(image.Image)
-	if !ok {
-		return nil, fmt.Errorf("input should be image.Image type")
-	}
+func (t *RandomFlipTransformer) Run(input image.Image) image.Image {
 	rand.Seed(time.Now().UnixNano())
 	if rand.Float32() >= 0.5 {
-		return imaging.FlipH(i), nil
+		return imaging.FlipH(input)
 	}
-	return i, nil
+	return input
 }

--- a/vision/transforms/random_flip_test.go
+++ b/vision/transforms/random_flip_test.go
@@ -13,13 +13,10 @@ func TestRandomFlip(t *testing.T) {
 	width := i.Bounds().Max.X
 
 	trans := RandomFlip()
-	_, err := trans.Run(100)
-	a.Error(err)
 
 	// Run 10 times to cover random cases
 	for j := 0; j < 10; j++ {
-		o, err := trans.Run(i)
-		a.NoError(err)
+		o := trans.Run(i)
 		outImage := o.(*image.NRGBA)
 		inImage := i.(*image.NRGBA)
 		a.True(inImage.At(0, 0) == outImage.At(0, 0) || inImage.At(0, 0) == outImage.At(width-1, 0))

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -1,0 +1,54 @@
+package transforms
+
+import (
+	"fmt"
+	"image"
+	"unsafe"
+
+	torch "github.com/wangkuiyi/gotorch"
+)
+
+// ToTensorTransformer transforms an object to Tensor
+type ToTensorTransformer struct{}
+
+// ToTensor returns ToTensorTransformer
+func ToTensor() *ToTensorTransformer {
+	return &ToTensorTransformer{}
+}
+
+// Run executes the ToTensorTransformer and returns a Tensor
+func (t ToTensorTransformer) Run(obj interface{}) torch.Tensor {
+	switch v := obj.(type) {
+	case image.Image:
+		return imageToTensor(obj.(image.Image))
+	case int:
+		return intToTensor(obj.(int))
+	default:
+		panic(fmt.Sprintf("ToTensor transform does not support type: %T", v))
+	}
+}
+
+// ToTensor transform c.f. https://github.com/pytorch/vision/blob/ba1b22125723f3719a3c38a2fe7cd6fb77657c57/torchvision/transforms/functional.py#L45
+func imageToTensor(img image.Image) torch.Tensor {
+	width, height := img.Bounds().Max.X, img.Bounds().Max.Y
+	// put pixel values with HWC format
+	array := make([][][3]float32, height)
+
+	for x := 0; x < height; x++ {
+		row := make([][3]float32, width)
+		for y := 0; y < width; y++ {
+			// ResNet need the 3 channels image, here we should convert to RGB format.
+			// The division by 255.0 is applied to convert RGB pixel values from [0, 255] to [0.0, 1.0] range
+			c := img.(*image.NRGBA).NRGBAAt(x, y)
+			row[y] = [3]float32{float32(c.R) / 255.0, float32(c.G) / 255.0, float32(c.B) / 255.0}
+		}
+		array[x] = row
+	}
+	return torch.FromBlob(unsafe.Pointer(&array[0][0][0]), torch.Float, []int64{int64(width), int64(height), 3})
+}
+
+func intToTensor(x int) torch.Tensor {
+	array := make([]int, 1)
+	array[0] = x
+	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Int, []int64{1})
+}

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -24,7 +24,7 @@ func (t ToTensorTransformer) Run(obj interface{}) torch.Tensor {
 	case int:
 		return intToTensor(obj.(int))
 	default:
-		panic(fmt.Sprintf("ToTensor transform does not support type: %T", v))
+		panic(fmt.Sprintf("ToTensorTransformer can not transform the input type: %T", v))
 	}
 }
 

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -1,0 +1,19 @@
+package transforms
+
+import (
+	"image"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToTensor(t *testing.T) {
+	// image to Tensor
+	m := generateRandImage(image.Rect(0, 0, 4, 4))
+	trans := ToTensor()
+	out := trans.Run(m)
+	assert.Equal(t, out.Shape(), []int64{4, 4, 3})
+	// int to Tensor
+	out = trans.Run(10)
+	assert.Equal(t, out.Shape(), []int64{1})
+}

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -8,12 +8,16 @@ import (
 )
 
 func TestToTensor(t *testing.T) {
+	a := assert.New(t)
 	// image to Tensor
 	m := generateRandImage(image.Rect(0, 0, 4, 4))
 	trans := ToTensor()
 	out := trans.Run(m)
-	assert.Equal(t, out.Shape(), []int64{4, 4, 3})
+	a.Equal(out.Shape(), []int64{4, 4, 3})
 	// int to Tensor
 	out = trans.Run(10)
-	assert.Equal(t, out.Shape(), []int64{1})
+	a.Equal(out.Shape(), []int64{1})
+	a.Panics(func() {
+		trans.Run("hello")
+	})
 }

--- a/vision/transforms/transforms_test.go
+++ b/vision/transforms/transforms_test.go
@@ -10,7 +10,7 @@ type plus struct {
 	value int
 }
 
-func (t plus) Do(x int) int {
+func (t plus) Run(x int) int {
 	return t.value + x
 }
 
@@ -18,7 +18,7 @@ type div struct {
 	value float32
 }
 
-func (t div) Do(a int) float32 {
+func (t div) Run(a int) float32 {
 	return float32(a) / t.value
 }
 
@@ -27,7 +27,7 @@ type invalidTransform struct{}
 func TestSequentialTransform(t *testing.T) {
 	transforms := Compose(&plus{10}, &div{2})
 	// (2 + 10) / 2
-	out := transforms.Do(2)
+	out := transforms.Run(2)
 	assert.Equal(t, out, float32(6.0))
 }
 
@@ -35,6 +35,6 @@ func TestSequentialTransformPanic(t *testing.T) {
 	a := assert.New(t)
 	a.Panics(func() {
 		transforms := Compose(&invalidTransform{})
-		transforms.Do(10)
+		transforms.Run(10)
 	}, "TestSequentialTransformPanic should panics")
 }


### PR DESCRIPTION
Fixed #147 

This PR refactor all functions in `vision/transforms` package to be with the Gotorch Transform design pattern and make it works with ImageNet dataloader.
