### PR TITLE
Improve gotorch/nn tests

### DIFF
--- a/nn/batchnorm_test.go
+++ b/nn/batchnorm_test.go
@@ -1,0 +1,15 @@
+package nn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	torch "github.com/wangkuiyi/gotorch"
+)
+
+func TestBatchNorm2d(t *testing.T) {
+	b := BatchNorm2d(100, 1e-5, 0.1, true, true)
+	x := torch.RandN([]int64{20, 100, 35, 45}, false)
+	output := b.Forward(x)
+	assert.NotNil(t, output.T)
+}

--- a/nn/conv_test.go
+++ b/nn/conv_test.go
@@ -1,0 +1,22 @@
+package nn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	torch "github.com/wangkuiyi/gotorch"
+)
+
+func TestConv2d(t *testing.T) {
+	c := Conv2d(16, 33, 3, 2, 0, 1, 1, true, "zeros")
+	x := torch.RandN([]int64{20, 16, 50, 100}, false)
+	output := c.Forward(x)
+	assert.NotNil(t, output)
+}
+
+func TestConvTranspose2d(t *testing.T) {
+	c := ConvTranspose2d(16, 33, 3, 2, 0, 1, 1, true, 1, "zeros")
+	x := torch.RandN([]int64{20, 16, 50, 100}, false)
+	output := c.Forward(x)
+	assert.NotNil(t, output.T)
+}

--- a/nn/conv_test.go
+++ b/nn/conv_test.go
@@ -7,16 +7,28 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 )
 
+// >>> c = torch.nn.Conv2d(16, 33, 3, 2, 0, 1, 1, True, "zeros")
+// >>> x = torch.randn(20, 16, 50, 100, requires_grad=False)
+// >>> y=c(x)
+// >>> y.shape
+// torch.Size([20, 33, 24, 49])
 func TestConv2d(t *testing.T) {
 	c := Conv2d(16, 33, 3, 2, 0, 1, 1, true, "zeros")
 	x := torch.RandN([]int64{20, 16, 50, 100}, false)
 	output := c.Forward(x)
-	assert.NotNil(t, output)
+	assert.NotNil(t, output.T)
+	assert.Equal(t, []int64{20, 33, 24, 49}, output.Shape())
 }
 
+// >>> c = torch.nn.ConvTranspose2d(16, 33, 3, 2, 0, 1, 1, True, 1, 'zeros')
+// >>> x = torch.randn(20, 16, 50, 100)
+// >>> y = c(x)
+// >>> y.shape
+// torch.Size([20, 33, 102, 202])
 func TestConvTranspose2d(t *testing.T) {
 	c := ConvTranspose2d(16, 33, 3, 2, 0, 1, 1, true, 1, "zeros")
 	x := torch.RandN([]int64{20, 16, 50, 100}, false)
 	output := c.Forward(x)
 	assert.NotNil(t, output.T)
+	assert.Equal(t, []int64{20, 33, 102, 202}, output.Shape())
 }

--- a/nn/module.go
+++ b/nn/module.go
@@ -10,15 +10,18 @@ import (
 
 // IModule is the interface of `Module`s
 type IModule interface {
-	// Train enables "training" mode
+	// Train corresponds to torch.nn.Module.train(bool). It effects only
+	// certain modules like Dropout and BatchNorm.
 	Train(on bool)
 	// IsTraining returns true if the module is in training mode
 	IsTraining() bool
-	// To recursively casts all parameters to the given `dtype` and `device`.
+	// To corresponds to torch.nn.Module.to().  It recursively casts all
+	// parameters to the given `dtype` and `device`.
 	To(device torch.Device)
-	// ZeroGrad recursively zeros out the `grad` value of each registered parameter.
+	// ZeroGrad corresponds to torch.nn.Module.zero_grad(). It recursively
+	// zeros out the `grad` value of each registered parameter.
 	ZeroGrad()
-	// String is for printing modules prettily
+	// String is for printing modules prettily.
 	String() string
 }
 

--- a/nn/module.go
+++ b/nn/module.go
@@ -21,8 +21,9 @@ type IModule interface {
 	// ZeroGrad corresponds to torch.nn.Module.zero_grad(). It recursively
 	// zeros out the `grad` value of each registered parameter.
 	ZeroGrad()
+	// TODO(shendiaomo): Implement this.
 	// String is for printing modules prettily.
-	String() string
+	// String() string
 }
 
 // Module contains default implementation of `Module`s
@@ -186,11 +187,11 @@ func (m *Module) ZeroGrad() {
 	}
 }
 
+// TODO(shendiaomo): to be implemented
 // String is for printing modules prettily
-func (m *Module) String() string {
-	// TODO(shendiaomo): to be implemented
-	return m.name
-}
+// func (m *Module) String() string {
+// 	return m.name
+// }
 
 // NamedParameters returns trainable parameters (recursively) with their names
 func (m *Module) NamedParameters() map[string]torch.Tensor {

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -49,14 +49,14 @@ func (n *myNetWithBuffer) Forward(x torch.Tensor) torch.Tensor {
 	return x
 }
 
-type hierarchyNet struct {
+type hierarchicalNet struct {
 	Module
 	L1 *myNet
 	L2 *LinearModule
 }
 
-func newHierarchyNet() *hierarchyNet {
-	n := &hierarchyNet{
+func newHierarchicalNet() *hierarchicalNet {
+	n := &hierarchicalNet{
 		L1: newMyNet(),
 		L2: Linear(200, 10, false),
 	}
@@ -65,7 +65,7 @@ func newHierarchyNet() *hierarchyNet {
 }
 
 // Forward executes the calculation
-func (n *hierarchyNet) Forward(x torch.Tensor) torch.Tensor {
+func (n *hierarchicalNet) Forward(x torch.Tensor) torch.Tensor {
 	x = n.L1.Forward(x)
 	x = n.L2.Forward(x)
 	return x
@@ -108,12 +108,12 @@ func TestModule(t *testing.T) {
 	assert.Equal(t, 1, len(namedParams2))
 	assert.Contains(t, namedParams2, "myNetWithBuffer.L1.Weight")
 
-	hn := newHierarchyNet()
+	hn := newHierarchicalNet()
 	hnNamedParams := hn.NamedParameters()
 	assert.Equal(t, 3, len(hnNamedParams))
-	assert.Contains(t, hnNamedParams, "hierarchyNet.L1.L1.Weight")
-	assert.Contains(t, hnNamedParams, "hierarchyNet.L1.L2.Weight")
-	assert.Contains(t, hnNamedParams, "hierarchyNet.L2.Weight")
+	assert.Contains(t, hnNamedParams, "hierarchicalNet.L1.L1.Weight")
+	assert.Contains(t, hnNamedParams, "hierarchicalNet.L1.L2.Weight")
+	assert.Contains(t, hnNamedParams, "hierarchicalNet.L2.Weight")
 }
 
 func TestModuleTrain(t *testing.T) {
@@ -123,7 +123,7 @@ func TestModuleTrain(t *testing.T) {
 	assert.False(t, n.L1.IsTraining())
 	assert.False(t, n.L2.IsTraining())
 
-	hn := newHierarchyNet()
+	hn := newHierarchicalNet()
 	hn.Train(false)
 	assert.False(t, hn.IsTraining())
 	assert.False(t, hn.L2.IsTraining())

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -1,6 +1,7 @@
 package nn
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -160,4 +161,18 @@ func TestNewModuleWithoutInit(t *testing.T) {
 	assert.Panics(t, func() { n.ZeroGrad() })
 	assert.Panics(t, func() { n.NamedParameters() })
 	assert.Panics(t, func() { n.NamedBuffers() })
+}
+
+func TestModuleToDevice(t *testing.T) {
+	var device torch.Device
+	if torch.IsCUDAAvailable() {
+		log.Println("CUDA is valid")
+		device = torch.NewDevice("cuda")
+	} else {
+		log.Println("No CUDA found; CPU only")
+		device = torch.NewDevice("cpu")
+	}
+
+	hn := newHierarchicalNet()
+	assert.NotPanics(t, func() { hn.To(device) })
 }

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -149,10 +149,13 @@ func TestModuleTrain(t *testing.T) {
 }
 
 func TestNewModuleWithoutInit(t *testing.T) {
-	newMyNetWithoutInit := func() *myNet {
-		return &myNet{
-			L1: Linear(100, 200, false),
-			L2: Linear(200, 10, false),
+	newMyNetWithoutInit := func() *hierarchicalNet {
+		return &hierarchicalNet{
+			L1: newMyNet(),
+			L2: []*LinearModule{
+				Linear(10, 10, false),
+				Linear(10, 5, false),
+			},
 		}
 	}
 	n := newMyNetWithoutInit()

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -28,14 +28,14 @@ func (n *myNet) Forward(x torch.Tensor) torch.Tensor {
 	return x
 }
 
-type myNet2 struct {
+type myNetWithBuffer struct {
 	Module
 	Weight torch.Tensor `gotorch:"buffer"`
 	L1     *LinearModule
 }
 
-func newMyNet2() *myNet2 {
-	n := &myNet2{
+func newMyNetWithBuffer() *myNetWithBuffer {
+	n := &myNetWithBuffer{
 		Weight: torch.RandN([]int64{100, 200}, false),
 		L1:     Linear(100, 200, false),
 	}
@@ -44,7 +44,7 @@ func newMyNet2() *myNet2 {
 }
 
 // Forward executes the calculation
-func (n *myNet2) Forward(x torch.Tensor) torch.Tensor {
+func (n *myNetWithBuffer) Forward(x torch.Tensor) torch.Tensor {
 	x = n.L1.Forward(x)
 	return x
 }
@@ -103,10 +103,10 @@ func TestModule(t *testing.T) {
 	assert.Contains(t, namedParams, "myNet.L1.Weight")
 	assert.Contains(t, namedParams, "myNet.L2.Weight")
 
-	n2 := newMyNet2()
+	n2 := newMyNetWithBuffer()
 	namedParams2 := n2.NamedParameters()
 	assert.Equal(t, 1, len(namedParams2))
-	assert.Contains(t, namedParams2, "myNet2.L1.Weight")
+	assert.Contains(t, namedParams2, "myNetWithBuffer.L1.Weight")
 
 	hn := newHierarchyNet()
 	hnNamedParams := hn.NamedParameters()

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -111,6 +111,8 @@ func TestModule(t *testing.T) {
 	namedParams2 := n2.NamedParameters()
 	assert.Equal(t, 1, len(namedParams2))
 	assert.Contains(t, namedParams2, "myNetWithBuffer.L1.Weight")
+	assert.Equal(t, 1, len(n2.Parameters()))
+	assert.Equal(t, 1, len(n2.Buffers()))
 
 	hn := newHierarchicalNet()
 	hnNamedParams := hn.NamedParameters()
@@ -119,6 +121,8 @@ func TestModule(t *testing.T) {
 	assert.Contains(t, hnNamedParams, "hierarchicalNet.L1.L2.Weight")
 	assert.Contains(t, hnNamedParams, "hierarchicalNet.L2[0].Weight")
 	assert.Contains(t, hnNamedParams, "hierarchicalNet.L2[1].Weight")
+	assert.Equal(t, 4, len(hn.Parameters()))
+	assert.Equal(t, 0, len(hn.Buffers()))
 }
 
 func TestModuleTrain(t *testing.T) {

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -137,27 +137,6 @@ func TestModuleTrain(t *testing.T) {
 	assert.False(t, n3.L2.IsTraining())
 }
 
-func TestConv2d(t *testing.T) {
-	c := Conv2d(16, 33, 3, 2, 0, 1, 1, true, "zeros")
-	x := torch.RandN([]int64{20, 16, 50, 100}, false)
-	output := c.Forward(x)
-	assert.NotNil(t, output)
-}
-
-func TestConvTranspose2d(t *testing.T) {
-	c := ConvTranspose2d(16, 33, 3, 2, 0, 1, 1, true, 1, "zeros")
-	x := torch.RandN([]int64{20, 16, 50, 100}, false)
-	output := c.Forward(x)
-	assert.NotNil(t, output.T)
-}
-
-func TestBatchNorm2d(t *testing.T) {
-	b := BatchNorm2d(100, 1e-5, 0.1, true, true)
-	x := torch.RandN([]int64{20, 100, 35, 45}, false)
-	output := b.Forward(x)
-	assert.NotNil(t, output.T)
-}
-
 func TestNewModuleWithoutInit(t *testing.T) {
 	newMyNetWithoutInit := func() *myNet {
 		return &myNet{


### PR DESCRIPTION
- Split module_test.go into several files, according to source code files.
- Add the case that a module definition contains a slice of sub-modules.
- Cover `Module.{Buffers|Parameters}`.
- Cover `Module.To`.
- Cover `Module.ZeroGrad` with the case that a module contains slices-of-modules.
- Comment out the not-yet-implemented `Module.String()`.
- Enrich the over-simplified tests `TestConv2d` and `TestConvTranspose2d`.

This PR improves the coverage of `nn/module.go` for over 31% to 90%.