### PR TITLE
Fix to tensor bug

### DIFF
--- a/vision/transforms/testing.go
+++ b/vision/transforms/testing.go
@@ -3,6 +3,7 @@ package transforms
 import (
 	"image"
 	"image/color"
+	"image/draw"
 	"math/rand"
 	"time"
 )
@@ -19,4 +20,10 @@ func generateRandImage(size image.Rectangle) image.Image {
 		}
 	}
 	return i
+}
+
+func drawImage(size image.Rectangle, c color.Color) image.Image {
+	m := image.NewRGBA(size)
+	draw.Draw(m, m.Bounds(), &image.Uniform{c}, image.ZP, draw.Src)
+	return m
 }

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -37,10 +37,8 @@ func imageToTensor(img image.Image) torch.Tensor {
 	for x := 0; x < height; x++ {
 		row := make([][3]float32, width)
 		for y := 0; y < width; y++ {
-			// ResNet need the 3 channels image, here we should convert to RGB format.
-			// The division by 255.0 is applied to convert RGB pixel values from [0, 255] to [0.0, 1.0] range
-			c := img.(*image.NRGBA).NRGBAAt(x, y)
-			row[y] = [3]float32{float32(c.R) / 255.0, float32(c.G) / 255.0, float32(c.B) / 255.0}
+			r, g, b, _ := img.At(x, y).RGBA()
+			row[y] = [3]float32{float32(r) / 255.0, float32(g) / 255.0, float32(b) / 255.0}
 		}
 		array[x] = row
 	}

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -30,25 +30,29 @@ func (t ToTensorTransformer) Run(obj interface{}) torch.Tensor {
 
 // ToTensor transform c.f. https://github.com/pytorch/vision/blob/ba1b22125723f3719a3c38a2fe7cd6fb77657c57/torchvision/transforms/functional.py#L45
 func imageToTensor(img image.Image) torch.Tensor {
-	width, height := img.Bounds().Max.X, img.Bounds().Max.Y
+	w, h := img.Bounds().Max.X, img.Bounds().Max.Y
 	// put pixel values with HWC format
-	array := make([][][3]float32, height)
-
-	for x := 0; x < height; x++ {
-		row := make([][3]float32, width)
-		for y := 0; y < width; y++ {
+	array := make([]float32, h*w*3)
+	denom := float32(0xffff)
+	i := 0
+	for x := 0; x < h; x++ {
+		for y := 0; y < w; y++ {
 			r, g, b, _ := img.At(x, y).RGBA()
-			row[y] = [3]float32{float32(r) / 255.0, float32(g) / 255.0, float32(b) / 255.0}
+			array[i] = float32(r) / denom
+			i++
+			array[i] = float32(g) / denom
+			i++
+			array[i] = float32(b) / denom
+			i++
 		}
-		array[x] = row
 	}
-	hwcTensor := torch.FromBlob(unsafe.Pointer(&array[0][0][0]), torch.Float, []int64{int64(width), int64(height), 3})
+	hwcTensor := torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float, []int64{int64(w), int64(h), 3})
 	// Convert Tensor to CHW format and return.
 	return hwcTensor.Permute([]int64{2, 0, 1})
 }
 
 func intToTensor(x int) torch.Tensor {
-	array := make([]int, 1)
-	array[0] = x
+	array := make([]int32, 1)
+	array[0] = int32(x)
 	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Int, []int64{1})
 }

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -15,11 +15,15 @@ func TestToTensor(t *testing.T) {
 	trans := ToTensor()
 	out := trans.Run(m)
 	a.Equal(out.Shape(), []int64{3, 2, 2})
-	t.Log(out.String())
+	a.Equal("(1,.,.) = \n  0  0\n  0  0\n\n(2,.,.) = \n  0  0\n  0  0\n\n(3,.,.) = \n  1  1\n  1  1\n[ CPUFloatType{3,2,2} ]",
+		out.String())
 
 	// int to Tensor
 	out = trans.Run(10)
 	a.Equal(out.Shape(), []int64{1})
+	a.Equal(" 10\n[ CPUIntType{1} ]", out.String())
+
+	// converting any other type to tensor would panic.
 	a.Panics(func() {
 		trans.Run("hello")
 	})

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -11,10 +11,12 @@ import (
 func TestToTensor(t *testing.T) {
 	a := assert.New(t)
 	// image to Tensor
-	m := drawImage(image.Rect(0, 0, 4, 4), color.RGBA{0, 0, 255, 255})
+	m := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
 	trans := ToTensor()
 	out := trans.Run(m)
-	a.Equal(out.Shape(), []int64{3, 4, 4})
+	a.Equal(out.Shape(), []int64{3, 2, 2})
+	t.Log(out.String())
+
 	// int to Tensor
 	out = trans.Run(10)
 	a.Equal(out.Shape(), []int64{1})

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -2,6 +2,7 @@ package transforms
 
 import (
 	"image"
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,7 @@ import (
 func TestToTensor(t *testing.T) {
 	a := assert.New(t)
 	// image to Tensor
-	m := generateRandImage(image.Rect(0, 0, 4, 4))
+	m := drawImage(image.Rect(0, 0, 4, 4), color.RGBA{0, 0, 255, 255})
 	trans := ToTensor()
 	out := trans.Run(m)
 	a.Equal(out.Shape(), []int64{3, 4, 4})


### PR DESCRIPTION
- Remove the type assertion without checking of success or failure.
- `torch.Int` means Go's `int32`, not `int`.
- It always fails to convert a Go slice-of-slice into a tensor using FromBlob.