### PR TITLE
Fix RandomCrop transformer

### DIFF
--- a/vision/transforms/random_crop.go
+++ b/vision/transforms/random_crop.go
@@ -15,8 +15,12 @@ type RandomCropTransformer struct {
 }
 
 // RandomCrop returns the RandomCropTransformer.
-func RandomCrop(width, height int) *RandomCropTransformer {
-	return &RandomCropTransformer{width, height}
+func RandomCrop(height int, width ...int) *RandomCropTransformer {
+	w := height
+	if len(width) > 0 {
+		w = width[0]
+	}
+	return &RandomCropTransformer{width: w, height: height}
 }
 
 // Run execute the random crop function and returns the cropped image object.

--- a/vision/transforms/random_crop.go
+++ b/vision/transforms/random_crop.go
@@ -30,8 +30,8 @@ func (t *RandomCropTransformer) Run(input image.Image) image.Image {
 	if h := input.Bounds().Max.Y; t.height > h {
 		log.Panicf("RandomCrop: wanted height %d larger than image height %d", t.height, h)
 	}
-	x := rand.Intn(input.Bounds().Max.X - t.width)
-	y := rand.Intn(input.Bounds().Max.Y - t.height)
+	x := rand.Intn(input.Bounds().Max.X - t.width + 1)
+	y := rand.Intn(input.Bounds().Max.Y - t.height + 1)
 
 	rect := image.Rectangle{
 		Min: image.Point{X: x, Y: y},

--- a/vision/transforms/random_crop.go
+++ b/vision/transforms/random_crop.go
@@ -1,10 +1,9 @@
 package transforms
 
 import (
-	"fmt"
 	"image"
+	"log"
 	"math/rand"
-	"time"
 
 	"github.com/disintegration/imaging"
 )
@@ -25,11 +24,12 @@ func RandomCrop(height int, width ...int) *RandomCropTransformer {
 
 // Run execute the random crop function and returns the cropped image object.
 func (t *RandomCropTransformer) Run(input image.Image) image.Image {
-	if t.width > input.Bounds().Max.X || t.height > input.Bounds().Max.Y {
-		panic(fmt.Sprintf("crop size (%d, %d) should be within image size (%d, %d)",
-			t.width, t.height, input.Bounds().Max.X, input.Bounds().Max.Y))
+	if w := input.Bounds().Max.X; t.width > w {
+		log.Panicf("RandomCrop: wanted width %d larger than image width %d", t.width, w)
 	}
-	rand.Seed(time.Now().UnixNano())
+	if h := input.Bounds().Max.Y; t.height > h {
+		log.Panicf("RandomCrop: wanted height %d larger than image height %d", t.height, h)
+	}
 	x := rand.Intn(input.Bounds().Max.X - t.width)
 	y := rand.Intn(input.Bounds().Max.Y - t.height)
 

--- a/vision/transforms/random_crop_test.go
+++ b/vision/transforms/random_crop_test.go
@@ -14,8 +14,8 @@ func TestRandomCrop(t *testing.T) {
 	m := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
 	trans := RandomCrop(1, 2)
 	cropped := trans.Run(m)
-	a.Equal(1, cropped.Bounds().Max.X)
-	a.Equal(2, cropped.Bounds().Max.Y)
+	a.Equal(2, cropped.Bounds().Max.X)
+	a.Equal(1, cropped.Bounds().Max.Y)
 }
 
 func TestRandomCropSizePanics(t *testing.T) {

--- a/vision/transforms/random_crop_test.go
+++ b/vision/transforms/random_crop_test.go
@@ -2,6 +2,7 @@ package transforms
 
 import (
 	"image"
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,11 +11,11 @@ import (
 func TestRandomCrop(t *testing.T) {
 	a := assert.New(t)
 
-	m := generateRandImage(image.Rect(0, 0, 200, 200))
-	trans := RandomCrop(100, 100)
+	m := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
+	trans := RandomCrop(1, 2)
 	cropped := trans.Run(m)
-	a.Equal(100, cropped.Bounds().Max.X)
-	a.Equal(100, cropped.Bounds().Max.Y)
+	a.Equal(1, cropped.Bounds().Max.X)
+	a.Equal(2, cropped.Bounds().Max.Y)
 }
 
 func TestRandomCropSizePanics(t *testing.T) {

--- a/vision/transforms/random_crop_test.go
+++ b/vision/transforms/random_crop_test.go
@@ -10,15 +10,19 @@ import (
 
 func TestRandomCrop(t *testing.T) {
 	a := assert.New(t)
+	blue := color.RGBA{0, 0, 255, 255}
 
-	m := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
+	m := drawImage(image.Rect(0, 0, 2, 2), blue)
 	trans := RandomCrop(1, 2)
 	cropped := trans.Run(m)
 	a.Equal(2, cropped.Bounds().Max.X)
 	a.Equal(1, cropped.Bounds().Max.Y)
+
+	a.True(colorEqual(blue, cropped.At(0, 0)))
+	a.True(colorEqual(blue, cropped.At(1, 0)))
 }
 
-func TestRandomCropSizePanics(t *testing.T) {
+func TestRandomCropWrongSizePanics(t *testing.T) {
 	a := assert.New(t)
 	m := generateRandImage(image.Rect(0, 0, 200, 200))
 	trans := RandomCrop(300, 300)

--- a/vision/transforms/random_crop_test.go
+++ b/vision/transforms/random_crop_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	blue = color.RGBA{0, 0, 255, 255}
+)
+
 func TestRandomCrop(t *testing.T) {
 	a := assert.New(t)
-	blue := color.RGBA{0, 0, 255, 255}
-
 	m := drawImage(image.Rect(0, 0, 2, 2), blue)
 	trans := RandomCrop(1, 2)
 	cropped := trans.Run(m)
@@ -24,8 +26,8 @@ func TestRandomCrop(t *testing.T) {
 
 func TestRandomCropWrongSizePanics(t *testing.T) {
 	a := assert.New(t)
-	m := generateRandImage(image.Rect(0, 0, 200, 200))
-	trans := RandomCrop(300, 300)
+	m := drawImage(image.Rect(0, 0, 1, 1), blue)
+	trans := RandomCrop(1, 2)
 	a.Panics(func() {
 		trans.Run(m)
 	})

--- a/vision/transforms/testing.go
+++ b/vision/transforms/testing.go
@@ -3,6 +3,7 @@ package transforms
 import (
 	"image"
 	"image/color"
+	"image/draw"
 	"math/rand"
 	"time"
 )
@@ -19,4 +20,10 @@ func generateRandImage(size image.Rectangle) image.Image {
 		}
 	}
 	return i
+}
+
+func drawImage(size image.Rectangle, c color.Color) image.Image {
+	m := image.NewRGBA(size)
+	draw.Draw(m, m.Bounds(), &image.Uniform{c}, image.ZP, draw.Src)
+	return m
 }

--- a/vision/transforms/testing.go
+++ b/vision/transforms/testing.go
@@ -27,3 +27,9 @@ func drawImage(size image.Rectangle, c color.Color) image.Image {
 	draw.Draw(m, m.Bounds(), &image.Uniform{c}, image.ZP, draw.Src)
 	return m
 }
+
+func colorEqual(x, y color.Color) bool {
+	r1, b1, g1, a1 := x.RGBA()
+	r2, b2, g2, a2 := y.RGBA()
+	return r1 == r2 && b1 == b2 && g1 == g2 && a1 == a2
+}


### PR DESCRIPTION
- Fix bug: `rand.Intn` takes input 0 when the cropped size equals to the original image size.
- More careful unit tests -- comparing expected colors.
- Signature compatible with PyTorch -- `RandomCrop(h, w)` other than `RandomCrop(w, h)`.
- Do not seed RNG in library code.
- Do not use random data in unit tests.