### PR TITLE
Fix ImageNet loader hangs at the second iteration

### DIFF
--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -98,7 +98,7 @@ func train(model *models.ResnetModule, opt torch.Optimizer, batchSize int, devic
 	batchIdx := 1
 	startTime := time.Now()
 	for loader.Scan() {
-		torch.GC()
+		loader.Minibatch()
 		image, target := loader.Minibatch()
 		image = image.To(device, torch.Float)
 		target = target.To(device, torch.Long)
@@ -128,7 +128,7 @@ func main() {
 		panic(e)
 	}
 
-	batchSize := 16
+	batchSize := 32
 	epochs := 100
 	lr := 0.1
 	momentum := 0.9

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -98,7 +98,6 @@ func train(model *models.ResnetModule, opt torch.Optimizer, batchSize int, devic
 	batchIdx := 1
 	startTime := time.Now()
 	for loader.Scan() {
-		loader.Minibatch()
 		image, target := loader.Minibatch()
 		image = image.To(device, torch.Float)
 		target = target.To(device, torch.Long)

--- a/tensor.go
+++ b/tensor.go
@@ -132,6 +132,7 @@ func To(a Tensor, device Device, dtype int8) Tensor {
 // FromBlob creating a Tensor with the give data memory
 func FromBlob(data unsafe.Pointer, dtype int8, sizes []int64) Tensor {
 	var t C.Tensor
-	C.Tensor_FromBlob(data, C.int8_t(dtype), (*C.int64_t)(unsafe.Pointer(&sizes[0])), C.int64_t(len(sizes)), &t)
+	MustNil(unsafe.Pointer(C.Tensor_FromBlob(data, C.int8_t(dtype), (*C.int64_t)(unsafe.Pointer(&sizes[0])), C.int64_t(len(sizes)), &t)))
+	SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return Tensor{(*unsafe.Pointer)(&t)}
 }

--- a/vision/datasets/imagenet_test.go
+++ b/vision/datasets/imagenet_test.go
@@ -11,22 +11,36 @@ import (
 )
 
 func TestImgNetLoader(t *testing.T) {
+	a := assert.New(t)
 	var tgz bytes.Buffer
 	synthesizeImages(&tgz)
 
 	vocab, e := datasets.BuildLabelVocabulary(bytes.NewReader(tgz.Bytes()))
-	assert.NoError(t, e)
-	assert.Equal(t, 2, len(vocab))
+	a.NoError(e)
+	a.Equal(3, len(vocab))
 
 	trans := transforms.Compose(transforms.RandomCrop(224, 224), transforms.RandomHorizontalFlip(0.5), transforms.ToTensor())
 	loader, e := datasets.ImageNet(bytes.NewReader(tgz.Bytes()), vocab, trans, 2)
-	assert.NoError(t, e)
-	for loader.Scan() {
+	a.NoError(e)
+	{
+		// the first iteration
+		a.True(loader.Scan())
 		data, label := loader.Minibatch()
-		assert.Equal(t, []int64{2, 3, 224, 224}, data.Shape())
-		assert.Equal(t, []int64{2}, label.Shape())
+		a.Equal([]int64{2, 3, 224, 224}, data.Shape())
+		a.Equal([]int64{2}, label.Shape())
+		a.NoError(loader.Err())
 	}
-	assert.NoError(t, loader.Err())
+	{
+		// the second iteration returns the last minibatch which contains
+		// one sample only.
+		a.True(loader.Scan())
+		data, label := loader.Minibatch()
+		a.Equal([]int64{1, 3, 224, 224}, data.Shape())
+		a.Equal([]int64{1}, label.Shape())
+		a.NoError(loader.Err())
+	}
+	// no more data
+	a.False(loader.Scan())
 }
 
 func TestBuildLabelVocabularyFail(t *testing.T) {

--- a/vision/datasets/synthesizer_test.go
+++ b/vision/datasets/synthesizer_test.go
@@ -18,10 +18,12 @@ func synthesizeImages(w io.Writer) []string {
 	colors := []color.Color{
 		color.RGBA{0, 0, 255, 255},
 		color.RGBA{0, 255, 0, 255},
+		color.RGBA{255, 255, 255, 255},
 	}
 	fns := []string{
 		"/images/training/blue/01.jpeg",
 		"/images/training/green/green.jpeg",
+		"/images/training/white/white.jpeg",
 	}
 	for i := 0; i < len(fns); i++ {
 		s.AddImage(fns[i], 469, 387, colors[i])


### PR DESCRIPTION
we should reset the `p.inputs` and `p.labels` before GC to decrease the reference count of tensors in loader.
