### PR TITLE
bugfix: RandomResizedCropTransfomer return empty Image

### DIFF
--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -77,7 +77,7 @@ func imageNetLoader(tarFile string, batchSize int) (*datasets.ImageNetLoader, er
 		return nil, e
 	}
 	trans := transforms.Compose(
-		transforms.RandomCrop(224, 224),
+		transforms.RandomResizedCrop(224),
 		transforms.RandomHorizontalFlip(0.5),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))

--- a/vision/transforms/random_resized_crop.go
+++ b/vision/transforms/random_resized_crop.go
@@ -26,7 +26,7 @@ func RandomResizedCrop(height int, width ...int) *RandomResizedCropTransformer {
 		w = width[0]
 	}
 	return RandomResizedCropD(
-		w, height,
+		height, w,
 		0.08, 1.0,
 		3.0/4.0, 4.0/3.0,
 		imaging.Linear,
@@ -91,8 +91,8 @@ func (t *RandomResizedCropTransformer) getParams(input image.Image) (int, int, i
 func (t *RandomResizedCropTransformer) Run(input image.Image) image.Image {
 	i, j, h, w := t.getParams(input)
 	cropped := imaging.Crop(input, image.Rectangle{
-		Min: image.Point{X: i, Y: j},
-		Max: image.Point{X: w, Y: h},
+		Min: image.Point{X: j, Y: i},
+		Max: image.Point{X: j + w, Y: i + h},
 	})
 	return imaging.Resize(cropped, t.width, t.height, t.interpolation)
 }

--- a/vision/transforms/random_resized_crop.go
+++ b/vision/transforms/random_resized_crop.go
@@ -46,6 +46,10 @@ func RandomResizedCropD(height, width int, scale0, scale1, ratio0, ratio1 float6
 	}
 }
 
+func uniform(from, to float64) float64 {
+	return (rand.Float64() + from) * (to - from)
+}
+
 func (t *RandomResizedCropTransformer) getParams(input image.Image) (int, int, int, int) {
 	width := input.Bounds().Max.X
 	height := input.Bounds().Max.Y
@@ -53,10 +57,10 @@ func (t *RandomResizedCropTransformer) getParams(input image.Image) (int, int, i
 
 	// try 10 times to generate random scaled image bounds.
 	for idx := 0; idx < 10; idx++ {
-		targetArea := float64(area) * ((rand.Float64() + t.scale0) * (t.scale1 - t.scale0))
+		targetArea := float64(area) * uniform(t.scale0, t.scale1)
 		logRatio0 := math.Log(t.ratio0)
 		logRatio1 := math.Log(t.ratio1)
-		aspectRatio := math.Exp((rand.Float64() + logRatio0) * (logRatio1 - logRatio0))
+		aspectRatio := math.Exp(uniform(logRatio0, logRatio1))
 
 		w := int(math.Round(math.Sqrt(targetArea * aspectRatio)))
 		h := int(math.Round(math.Sqrt(targetArea / aspectRatio)))

--- a/vision/transforms/random_resized_crop_test.go
+++ b/vision/transforms/random_resized_crop_test.go
@@ -27,15 +27,22 @@ func TestRandomResizedCrop(t *testing.T) {
 	a.Equal(50, out.Bounds().Max.Y)
 	a.True(colorEqual(red, out.At(19, 19)))
 
+	// bounds test for scalar and ratio equals to zero
+	trans = RandomResizedCropD(50, 50, 0.0, 0.0, 0.0, 0.0, imaging.Linear)
+	out = trans.Run(input)
+	a.Equal(0, out.Bounds().Max.X)
+	a.Equal(0, out.Bounds().Max.Y)
+
 	rand.Seed(1)
 	// Test crop output smaller size
 	trans = RandomResizedCrop(20)
 	out = trans.Run(input)
 	a.Equal(20, out.Bounds().Max.X)
 	r, g, b, _ := out.At(7, 5).RGBA()
-	a.Equal(uint32(0x2424), r)
+	// the resized image color should be between blue and red
+	a.True(r > uint32(0x0) && r < uint32(0xffff))
 	a.Equal(uint32(0x0000), g)
-	a.Equal(uint32(0xdbdb), b)
+	a.True(b > uint32(0x0) && b < uint32(0xffff))
 
 	// Test crop output greater size
 	trans = RandomResizedCrop(60, 80)

--- a/vision/transforms/random_resized_crop_test.go
+++ b/vision/transforms/random_resized_crop_test.go
@@ -32,14 +32,14 @@ func TestRandomResizedCrop(t *testing.T) {
 	trans = RandomResizedCrop(20)
 	out = trans.Run(input)
 	a.Equal(20, out.Bounds().Max.X)
-	r, g, b, _ := out.At(4, 11).RGBA()
-	a.Equal(uint32(0x4242), r)
+	r, g, b, _ := out.At(7, 5).RGBA()
+	a.Equal(uint32(0x2424), r)
 	a.Equal(uint32(0x0000), g)
-	a.Equal(uint32(0xbdbd), b)
+	a.Equal(uint32(0xdbdb), b)
 
 	// Test crop output greater size
 	trans = RandomResizedCrop(60, 80)
 	out = trans.Run(input)
-	a.Equal(60, out.Bounds().Max.X)
-	a.Equal(80, out.Bounds().Max.Y)
+	a.Equal(80, out.Bounds().Max.X)
+	a.Equal(60, out.Bounds().Max.Y)
 }


### PR DESCRIPTION
The `crop` function accepts the position `(x, y, x+w, y+h)` instead of the crop box width and height.
c.f. https://github.com/pytorch/vision/blob/master/torchvision/transforms/functional_pil.py#L320
