### PR TITLE
Add variation of Item()

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -77,6 +77,8 @@ const char *Argmin(Tensor a, int64_t *dim, int8_t keepdim, Tensor *result);
 const char *Argmax(Tensor a, int64_t *dim, int8_t keepdim, Tensor *result);
 // TODO(qijun) only support float
 const char *Item(Tensor a, float *result);
+const char *ItemInt64(Tensor a, int64_t *result);
+const char *ItemFloat64(Tensor a, double *result);
 const char *Mean(Tensor a, Tensor *result);
 const char *Stack(Tensor *tensors, int64_t tensors_size, int64_t dim,
                   Tensor *result);

--- a/cgotorch/tensor.cc
+++ b/cgotorch/tensor.cc
@@ -28,6 +28,24 @@ const char *Item(Tensor a, float *result) {
   }
 }
 
+const char *ItemInt64(Tensor a, int64_t *result) {
+  try {
+    *result = a->item<int64_t>();
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
+const char *ItemFloat64(Tensor a, double *result) {
+  try {
+    *result = a->item<double>();
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *Mean(Tensor a, Tensor *result) {
   try {
     *result = new at::Tensor(a->mean());

--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -122,7 +122,7 @@ func main() {
 			output = netD.Forward(fake.Detach()).(torch.Tensor).View([]int64{-1, 1}).Squeeze(1)
 			errDFake := F.BinaryCrossEntropy(output, label, torch.Tensor{}, "mean")
 			errDFake.Backward()
-			errD := errDReal.Item() + errDFake.Item()
+			errD := errDReal.Item().(float32) + errDFake.Item().(float32)
 			optimizerD.Step()
 
 			// (2) update G network

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -46,7 +46,7 @@ func main() {
 			loss := F.NllLoss(pred, target, torch.Tensor{}, -100, "mean")
 			loss.Backward()
 			opt.Step()
-			lastLoss = loss.Item()
+			lastLoss = loss.Item().(float32)
 			iters++
 		}
 		log.Printf("Epoch: %d, Loss: %.4f", epoch, lastLoss)

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -68,7 +68,7 @@ func accuracy(output, target torch.Tensor, topk []int64) []float32 {
 	for _, k := range topk {
 		kt := torch.NewTensor(rangeI(k)).CopyTo(device)
 		correctK := correct.IndexSelect(0, kt).View([]int64{-1}).CastTo(torch.Float).SumByDim(0, true)
-		res = append(res, correctK.Item()*100/float32(mbSize))
+		res = append(res, correctK.Item().(float32)*100/float32(mbSize))
 	}
 	return res
 }
@@ -95,7 +95,7 @@ func trainOneMinibatch(image, target torch.Tensor, model *models.ResnetModule, o
 	acc5 := acc[1]
 	loss.Backward()
 	opt.Step()
-	return loss.Item(), acc1, acc5
+	return loss.Item().(float32), acc1, acc5
 }
 
 func main() {

--- a/tensor_ops.go
+++ b/tensor_ops.go
@@ -186,6 +186,7 @@ func (a Tensor) IndexSelect(dim int64, index Tensor) Tensor {
 // Item returns 0-dim tensor's value as an interface
 // users should do type assertion and get the value like:
 // v, ok := a.Item().(float64)
+// Currently not support unsigned Tensor.
 func (a Tensor) Item() interface{} {
 	dtype := a.Dtype()
 	switch dtype {

--- a/tensor_ops_test.go
+++ b/tensor_ops_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	torch "github.com/wangkuiyi/gotorch"
+	"github.com/x448/float16"
 )
 
 // >>> t = torch.tensor([[-0.5, -1.], [1., 0.5]])
@@ -282,6 +283,10 @@ func TestArgmax(t *testing.T) {
 	assert.Equal(t, " 1\n 0\n[ CPULongType{2,1} ]", x.Argmax(1, true).String())
 }
 
+func f16(x float32) uint16 {
+	return float16.Fromfloat32(x).Bits()
+}
+
 func TestItem(t *testing.T) {
 	x := torch.NewTensor([]byte{1})
 	y := x.Item()
@@ -329,6 +334,20 @@ func TestItem(t *testing.T) {
 	x = torch.NewTensor([]int32{-0x8000_0000})
 	y = x.Item()
 	assert.Equal(t, int32(-0x8000_0000), y)
+
+	// half
+	x = torch.NewTensor([]uint16{f16(1)})
+	y = x.Item()
+	assert.Equal(t, float32(1), y)
+
+	// max half
+	x = torch.NewTensor([]uint16{f16(65504)})
+	y = x.Item()
+	assert.Equal(t, float32(65504), y)
+
+	x = torch.NewTensor([]uint16{f16(0.25)})
+	y = x.Item()
+	assert.Equal(t, float32(0.25), y)
 
 	x = torch.NewTensor([]float32{1.0})
 	y = x.Item()

--- a/tensor_ops_test.go
+++ b/tensor_ops_test.go
@@ -1,6 +1,7 @@
 package gotorch_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -134,12 +135,6 @@ func TestIndexSelect(t *testing.T) {
 	y := torch.IndexSelect(x, 0, indices)
 	assert.Equal(t, int64(2), y.Shape()[0])
 	assert.Equal(t, int64(4), y.Shape()[1])
-}
-
-func TestItem(t *testing.T) {
-	x := torch.NewTensor([]float32{1})
-	y := x.Item()
-	assert.Equal(t, float32(1), y)
 }
 
 // >>> torch.nn.functional.leaky_relu(torch.tensor([[-0.5, -1.], [1., 0.5]]))
@@ -285,4 +280,61 @@ func TestArgmax(t *testing.T) {
 	assert.Equal(t, " 0  0\n[ CPULongType{1,2} ]", x.Argmax(0, true).String())
 	// x.argmax(1, True)
 	assert.Equal(t, " 1\n 0\n[ CPULongType{2,1} ]", x.Argmax(1, true).String())
+}
+
+func TestItem(t *testing.T) {
+	x := torch.NewTensor([]byte{1})
+	y := x.Item()
+	assert.Equal(t, byte(1), y)
+	assert.NotEqual(t, int8(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Uint8)
+
+	x = torch.NewTensor([]int8{1})
+	y = x.Item()
+	assert.Equal(t, int8(1), y)
+	assert.NotEqual(t, byte(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Int8)
+
+	x = torch.NewTensor([]int16{1})
+	y = x.Item()
+	assert.Equal(t, int16(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Int16)
+
+	x = torch.NewTensor([]int32{1})
+	y = x.Item()
+	assert.Equal(t, int32(1), y)
+	assert.NotEqual(t, int64(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Int32)
+
+	x = torch.NewTensor([]int64{1})
+	y = x.Item()
+	assert.Equal(t, int64(1), y)
+	assert.NotEqual(t, int32(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Int64)
+
+	x = torch.NewTensor([]int32{0x7FFF_FFFF})
+	y = x.Item()
+	assert.Equal(t, int32(0x7FFF_FFFF), y)
+
+	x = torch.NewTensor([]int32{-0x8000_0000})
+	y = x.Item()
+	assert.Equal(t, int32(-0x8000_0000), y)
+
+	x = torch.NewTensor([]float32{1.0})
+	y = x.Item()
+	assert.Equal(t, float32(1.0), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Float32)
+
+	x = torch.NewTensor([]float32{-1.0})
+	y = x.Item()
+	assert.Equal(t, float32(-1.0), y)
+
+	x = torch.NewTensor([]float64{1.0})
+	y = x.Item()
+	assert.Equal(t, float64(1), y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Float64)
+
+	x = torch.NewTensor([]float64{-1})
+	y = x.Item()
+	assert.Equal(t, float64(-1), y)
 }

--- a/tensor_ops_test.go
+++ b/tensor_ops_test.go
@@ -289,6 +289,16 @@ func TestItem(t *testing.T) {
 	assert.NotEqual(t, int8(1), y)
 	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Uint8)
 
+	x = torch.NewTensor([]bool{true})
+	y = x.Item()
+	assert.Equal(t, true, y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Bool)
+
+	x = torch.NewTensor([]bool{false})
+	y = x.Item()
+	assert.Equal(t, false, y)
+	assert.Equal(t, reflect.TypeOf(y).Kind(), reflect.Bool)
+
 	x = torch.NewTensor([]int8{1})
 	y = x.Item()
 	assert.Equal(t, int8(1), y)


### PR DESCRIPTION
We can get the value of a  0-dim tensor by `Item()`, however the data type in the tensor may be different. It can be float32, float64, int or many others.
We may return the value by an interface like: `func Item() interface{}`. However we still need to do dispatch in Go. So, I add some variation of the `Item` like `ItemInt64`, I think explicit type functions can make it easier in later usage.