### PR TITLE
Fix cgotorch/build.sh to use regexp match the arm arch

### DIFF
--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -13,27 +13,27 @@ LOAD="force_load"
 LIB_SUFFIX="so"
 INSTALL_NAME=""
 
-if [ "$OS" == "linux" ]; then
-    if [ "$ARCH" == "arm" ]; then
+if [[ "$OS" == "linux" ]]; then
+    if [[ "$ARCH" =~ arm* ]]; then
         echo "Building for Raspbian ...";
         LIBTORCH_DIR="rpi/libtorch"
-        if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
+        if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
             curl -LsO 'https://github.com/ljk53/pytorch-rpi/raw/master/libtorch-rpi-cxx11-abi-shared-1.6.0.zip';
             unzip -qq -o libtorch-rpi-cxx11-abi-shared-1.6.0.zip -d rpi
         fi
     elif $(whereis cuda | cut -f 2 -d ' ')/bin/nvcc --version > /dev/null; then
         CUDA_VERSION=`nvcc --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1`
-        if [ "$CUDA_VERSION" == "10.1" ]; then
+        if [[ "$CUDA_VERSION" == "10.1" ]]; then
             echo "Building for Linux with CUDA 10.1";
             LIBTORCH_DIR="linux-cuda101/libtorch"
-            if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
+            if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
                 curl -Lso libtorch-cxx11-1.6.0-linux-cuda101.zip 'https://download.pytorch.org/libtorch/cu101/libtorch-cxx11-abi-shared-with-deps-1.6.0%2Bcu101.zip'
                 unzip -qq -o libtorch-cxx11-1.6.0-linux-cuda101.zip -d linux-cuda101
             fi
-        elif [ "$CUDA_VERSION" == "10.2" ]; then
+        elif [[ "$CUDA_VERSION" == "10.2" ]]; then
             echo "Building for Linux with CUDA 10.2";
             LIBTORCH_DIR="linux-cuda102/libtorch"
-            if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
+            if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
                 curl -Lso libtorch-cxx11-1.6.0-linux-cuda102.zip 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip'
                 unzip -qq -o libtorch-cxx11-1.6.0-linux-cuda102.zip -d linux-cuda102
             fi
@@ -42,18 +42,18 @@ if [ "$OS" == "linux" ]; then
         echo "Building for Linux without CUDA ...";
         LIBTORCH_DIR="linux/libtorch"
         GLIBCXX_USE_CXX11_ABI="0"
-        if [ ! -d "DIR/$LIBTORCH_DIR" ]; then
+        if [[ ! -d "DIR/$LIBTORCH_DIR" ]]; then
             curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.6.0%2Bcpu.zip'
             unzip -qq -o libtorch-shared-with-deps-1.6.0%2Bcpu.zip -d linux
         fi
     fi
-elif [ "$OS" == "darwin" ]; then
+elif [[ "$OS" == "darwin" ]]; then
     echo "Building for macOS ...";
     LIBTORCH_DIR="macos/libtorch"
     LIB_SUFFIX="dylib"
     INSTALL_NAME="-install_name @rpath/\$@"
     LOAD="all_load"
-    if [ ! -d "$DIR/$LIBTORCH_DIR" ]; then
+    if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
         curl -LsO https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.6.0.zip
         unzip -qq -o libtorch-macos-1.6.0.zip -d macos
     fi


### PR DESCRIPTION
- Use bash `=~` for regexp matching, because `$(uname -m)` prints `armvl7` instead of `arm` on Raspberry Pi.
- Use bash condition `[[ ]]` instead of that of sh `[ ]`.