### PR TITLE
Remove unused code - Module.ZeroGrad and Module.String

### DIFF
--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -28,12 +28,12 @@ func main() {
 		[]transforms.Transform{transforms.Normalize([]float64{0.1307}, []float64{0.3081})})
 
 	net := models.MLP()
-	net.ZeroGrad()
+	// net.ZeroGrad()
 	net.To(device)
 	opt := torch.SGD(0.01, 0.5, 0, 0, false)
 	opt.AddParameters(net.Parameters())
 
-	epochs := 2
+	epochs := 5
 	startTime := time.Now()
 	var lastLoss float32
 	iters := 0

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -28,7 +28,6 @@ func main() {
 		[]transforms.Transform{transforms.Normalize([]float64{0.1307}, []float64{0.3081})})
 
 	net := models.MLP()
-	// net.ZeroGrad()
 	net.To(device)
 	opt := torch.SGD(0.01, 0.5, 0, 0, false)
 	opt.AddParameters(net.Parameters())

--- a/mnist_test.go
+++ b/mnist_test.go
@@ -29,7 +29,6 @@ func ExampleTrainMNISTSequential() {
 		nn.Functional(torch.Tanh),
 		nn.Linear(512, 10, false))}
 	net.Init(net)
-	net.ZeroGrad()
 
 	mnist := datasets.MNIST("",
 		[]transforms.Transform{transforms.Normalize([]float64{0.1307}, []float64{0.3081})})

--- a/nn/module.go
+++ b/nn/module.go
@@ -18,12 +18,6 @@ type IModule interface {
 	// To corresponds to torch.nn.Module.to().  It recursively casts all
 	// parameters to the given `dtype` and `device`.
 	To(device torch.Device)
-	// ZeroGrad corresponds to torch.nn.Module.zero_grad(). It recursively
-	// zeros out the `grad` value of each registered parameter.
-	ZeroGrad()
-	// TODO(shendiaomo): Implement this.
-	// String is for printing modules prettily.
-	// String() string
 }
 
 // Module contains default implementation of `Module`s
@@ -142,56 +136,6 @@ func (m *Module) To(device torch.Device) {
 		}
 	}
 }
-
-// ZeroGrad recursively zeros out the `grad` value of each registered parameter.
-func (m *Module) ZeroGrad() {
-	must(m.outer != nil, "GoTorch modules requires calling `Init` before using")
-	moduleType := reflect.TypeOf((*IModule)(nil)).Elem()
-	tensorType := reflect.TypeOf((*torch.Tensor)(nil)).Elem()
-	sv := reflect.ValueOf(m.outer).Elem() // Elem gets what the pointer points to.
-	for i := 0; i < sv.NumField(); i++ {
-		f := sv.Type().Field(i)
-		v := sv.Field(i)
-		// TODO(shendiaomo): take reflect.Map into consideration
-		if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
-			for j := 0; j < v.Len(); j++ {
-				must(v.CanInterface(),
-					"GoTorch requires exporting Module field %s.%s", sv.Type().Name(), f.Name)
-				if m, ok := v.Index(j).Interface().(IModule); ok {
-					if !reflect.ValueOf(m).IsNil() {
-						m.ZeroGrad()
-					}
-				}
-			}
-		} else if f.Type.Implements(moduleType) {
-			if sv.Type() == moduleType && v.Addr() == reflect.ValueOf(m.outer).Addr() {
-				// Skip `outer` itself
-				continue
-			}
-			must(v.CanInterface(),
-				"GoTorch requires exporting Module field %s.%s", sv.Type().Name(), f.Name)
-			if m, ok := v.Interface().(IModule); ok {
-				if !reflect.ValueOf(m).IsNil() {
-					m.ZeroGrad()
-				}
-			}
-		} else if f.Type == tensorType {
-			/* TODO(shendiaomo): implement `Grad`, `Defined` and `Detach`
-			grad := v.Interface().(torch.Tensor).Grad()
-			if grad.Defined() {
-				grad = grad.Detach()
-				grad.Zero_()
-			}
-			*/
-		}
-	}
-}
-
-// TODO(shendiaomo): to be implemented
-// String is for printing modules prettily
-// func (m *Module) String() string {
-// 	return m.name
-// }
 
 // NamedParameters returns trainable parameters (recursively) with their names
 func (m *Module) NamedParameters() map[string]torch.Tensor {

--- a/nn/module_test.go
+++ b/nn/module_test.go
@@ -104,7 +104,6 @@ func (n *myNet3) Forward(x torch.Tensor) torch.Tensor {
 
 func TestModule(t *testing.T) {
 	n := newMyNet()
-	n.ZeroGrad()
 	namedParams := n.NamedParameters()
 	assert.Equal(t, 2, len(namedParams))
 	assert.Contains(t, namedParams, "myNet.L1.Weight")
@@ -163,7 +162,6 @@ func TestNewModuleWithoutInit(t *testing.T) {
 	n := newMyNetWithoutInit()
 	assert.Panics(t, func() { n.Train(true) })
 	assert.Panics(t, func() { n.To(torch.NewDevice("cpu")) })
-	assert.Panics(t, func() { n.ZeroGrad() })
 	assert.Panics(t, func() { n.NamedParameters() })
 	assert.Panics(t, func() { n.NamedBuffers() })
 }


### PR DESCRIPTION
We don't need `Module.ZeroGrad` and we never used it, because we have `Optimizer.ZeroGrad`, which clear gradients of the given parameter list returned by `Module.Parameters()`.

Also, the current implementation of `Module.ZeroGrad` is incomplete.

Similarly, we don't need and never used and have completely implemented `Module.String()`.