### PR TITLE
Support converting gray images into 1-channel tensors

### DIFF
--- a/vision/transforms/testing_test.go
+++ b/vision/transforms/testing_test.go
@@ -12,6 +12,12 @@ func drawImage(size image.Rectangle, c color.Color) image.Image {
 	return m
 }
 
+func drawGrayImage(size image.Rectangle, c color.Color) image.Image {
+	m := image.NewGray(size)
+	draw.Draw(m, m.Bounds(), &image.Uniform{c}, image.ZP, draw.Src)
+	return m
+}
+
 func colorEqual(x, y color.Color) bool {
 	r1, b1, g1, a1 := x.RGBA()
 	r2, b2, g2, a2 := y.RGBA()

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -8,7 +8,9 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 )
 
-// ToTensorTransformer transforms an object to Tensor
+// ToTensorTransformer transforms an image or an interger into a Tensor.  If the
+// image is of type image.Gray, the tensor has one channle; otherwise, the
+// tensor has three channels (RGB).
 type ToTensorTransformer struct{}
 
 // ToTensor returns ToTensorTransformer
@@ -30,10 +32,19 @@ func (t ToTensorTransformer) Run(obj interface{}) torch.Tensor {
 
 // ToTensor transform c.f. https://github.com/pytorch/vision/blob/ba1b22125723f3719a3c38a2fe7cd6fb77657c57/torchvision/transforms/functional.py#L45
 func imageToTensor(img image.Image) torch.Tensor {
+	switch img.(type) {
+	case *image.Gray, *image.Gray16:
+		return grayImageToTensor(img)
+	}
+	return colorImageToTensor(img)
+}
+
+func colorImageToTensor(img image.Image) torch.Tensor {
 	w, h := img.Bounds().Max.X, img.Bounds().Max.Y
-	// put pixel values with HWC format
-	array := make([]float32, h*w*3)
-	denom := float32(0xffff)
+	array := make([]float32, h*w*3) // 3 channels
+
+	// Convert pixels into the HWC format
+	const denom = float32(0xffff)
 	i := 0
 	for x := 0; x < h; x++ {
 		for y := 0; y < w; y++ {
@@ -46,9 +57,27 @@ func imageToTensor(img image.Image) torch.Tensor {
 			i++
 		}
 	}
-	hwcTensor := torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float, []int64{int64(w), int64(h), 3})
-	// Convert Tensor to CHW format and return.
-	return hwcTensor.Permute([]int64{2, 0, 1})
+	hwc := torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float,
+		[]int64{int64(w), int64(h), 3})
+	return hwc.Permute([]int64{2, 0, 1})
+}
+
+func grayImageToTensor(img image.Image) torch.Tensor {
+	w, h := img.Bounds().Max.X, img.Bounds().Max.Y
+	array := make([]float32, h*w) // 1 channel
+
+	// Convert pixels into the HWC format
+	const denom = float32(0xffff)
+	i := 0
+	for x := 0; x < h; x++ {
+		for y := 0; y < w; y++ {
+			r, _, _, _ := img.At(x, y).RGBA()
+			array[i] = float32(r) / denom
+			i++
+		}
+	}
+	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float,
+		[]int64{int64(w), int64(h)})
 }
 
 func intToTensor(x int) torch.Tensor {

--- a/vision/transforms/to_tensor_test.go
+++ b/vision/transforms/to_tensor_test.go
@@ -8,23 +8,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestToTensor(t *testing.T) {
-	a := assert.New(t)
-	// image to Tensor
+func TestToTensorColorImage(t *testing.T) {
 	m := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
-	trans := ToTensor()
-	out := trans.Run(m)
-	a.Equal(out.Shape(), []int64{3, 2, 2})
-	a.Equal("(1,.,.) = \n  0  0\n  0  0\n\n(2,.,.) = \n  0  0\n  0  0\n\n(3,.,.) = \n  1  1\n  1  1\n[ CPUFloatType{3,2,2} ]",
+	out := ToTensor().Run(m)
+	assert.Equal(t, []int64{3, 2, 2}, out.Shape())
+	assert.Equal(t,
+		"(1,.,.) = \n  0  0\n  0  0\n\n(2,.,.) = \n  0  0\n  0  0\n\n(3,.,.) = \n  1  1\n  1  1\n[ CPUFloatType{3,2,2} ]",
 		out.String())
+}
 
-	// int to Tensor
-	out = trans.Run(10)
-	a.Equal(out.Shape(), []int64{1})
-	a.Equal(" 10\n[ CPUIntType{1} ]", out.String())
+func TestToTensorGrayImage(t *testing.T) {
+	m := drawGrayImage(image.Rect(0, 0, 2, 2), color.Gray{127})
+	out := ToTensor().Run(m)
+	assert.Equal(t, []int64{2, 2}, out.Shape())
+	assert.Equal(t,
+		" 0.4980  0.4980\n 0.4980  0.4980\n[ CPUFloatType{2,2} ]",
+		out.String())
+}
 
-	// converting any other type to tensor would panic.
-	a.Panics(func() {
-		trans.Run("hello")
+func TestToTensorInteger(t *testing.T) {
+	out := ToTensor().Run(10)
+	assert.Equal(t, out.Shape(), []int64{1})
+	assert.Equal(t, " 10\n[ CPUIntType{1} ]", out.String())
+}
+
+func TestToTensorUnknownTypePanics(t *testing.T) {
+	assert.Panics(t, func() {
+		ToTensor().Run("hello")
 	})
 }


### PR DESCRIPTION
We need this change; otherwise, the prediction of the MNIST example generates three identical results for each input image, as all MNIST images are gray but converted input a 3-channel image.