### PR TITLE
ImageLoader to loader MNIST dataset with tgz file

### DIFF
--- a/example/mnist_tgzloader/mnist.go
+++ b/example/mnist_tgzloader/mnist.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	torch "github.com/wangkuiyi/gotorch"
+	"github.com/wangkuiyi/gotorch/nn"
+	F "github.com/wangkuiyi/gotorch/nn/functional"
+	"github.com/wangkuiyi/gotorch/nn/initializer"
+	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/models"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
+)
+
+var device torch.Device
+
+// MNISTLoader returns a ImageLoader with MNIST training or testing tgz file
+func MNISTLoader(fn string, vocab map[string]int64) *datasets.ImageLoader {
+	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float64{0.1307}, []float64{0.3081}))
+	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64)
+	if e != nil {
+		panic(e)
+	}
+	return loader
+}
+
+func test(model nn.IModule, loader *datasets.ImageLoader) {
+	testLoss := float32(0)
+	correct := float32(0)
+	samples := 0
+	for loader.Scan() {
+		data, label := loader.Minibatch()
+		data = data.To(device, data.Dtype())
+		label = label.To(device, label.Dtype())
+		output := model.(*models.MLPModule).Forward(data)
+		loss := F.NllLoss(output, label, torch.Tensor{}, -100, "mean")
+		pred := output.Argmax(1)
+		testLoss += loss.Item()
+		correct += pred.Eq(label.View(pred.Shape())).SumByDim(0, false).Item()
+		samples += int(label.Shape()[0])
+	}
+	log.Printf("Test average loss: %.4f, Accuracy: %.2f%%\n", testLoss/float32(samples), 100.0*correct/float32(samples))
+}
+
+func train(trainFn string, testFn string, epochs int) {
+	vocab, e := datasets.BuildLabelVocabularyFromTgz(trainFn)
+	if e != nil {
+		panic(e)
+	}
+	net := models.MLP()
+	net.To(device)
+	opt := torch.SGD(0.01, 0.5, 0, 0, false)
+	opt.AddParameters(net.Parameters())
+	defer torch.FinishGC()
+
+	for epoch := 0; epoch < epochs; epoch++ {
+		var trainLoss float32
+		startTime := time.Now()
+		trainLoader := MNISTLoader(trainFn, vocab)
+		testLoader := MNISTLoader(testFn, vocab)
+		totalSamples := 0
+		for trainLoader.Scan() {
+			data, label := trainLoader.Minibatch()
+			totalSamples += int(data.Shape()[0])
+			opt.ZeroGrad()
+			pred := net.Forward(data.To(device, data.Dtype()))
+			loss := F.NllLoss(pred, label.To(device, label.Dtype()), torch.Tensor{}, -100, "mean")
+			loss.Backward()
+			opt.Step()
+			trainLoss = loss.Item()
+		}
+		throughput := float64(totalSamples) / time.Since(startTime).Seconds()
+		log.Printf("Train Epoch: %d, Loss: %.4f, throughput: %f samples/sec", epoch, trainLoss, throughput)
+		test(net, testLoader)
+	}
+}
+
+func main() {
+	trainFn := flag.String("train-file", "train.tgz", "training images tgz file.")
+	testFn := flag.String("test-file", "test.tgz", "testing images tgz file")
+	flag.Parse()
+
+	if torch.IsCUDAAvailable() {
+		log.Println("CUDA is valid")
+		device = torch.NewDevice("cuda")
+	} else {
+		log.Println("No CUDA found; CPU only")
+		device = torch.NewDevice("cpu")
+	}
+
+	initializer.ManualSeed(1)
+	train(*trainFn, *testFn, 5 /**epochs**/)
+}

--- a/vision/datasets/imageloader.go
+++ b/vision/datasets/imageloader.go
@@ -1,0 +1,116 @@
+package datasets
+
+import (
+	"image"
+	"io"
+	"path/filepath"
+
+	torch "github.com/wangkuiyi/gotorch"
+	tgz "github.com/wangkuiyi/gotorch/tool/tgz"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
+)
+
+// ImageLoader struct
+type ImageLoader struct {
+	r      *tgz.Reader
+	vocab  map[string]int64
+	err    error
+	inputs []torch.Tensor
+	labels []int64
+	trans  *transforms.ComposeTransformer
+	mbSize int
+}
+
+func (p *ImageLoader) tensorGC() {
+	p.inputs = []torch.Tensor{}
+	p.labels = []int64{}
+	torch.GC()
+}
+
+// NewImageLoader returns an ImageLoader
+func NewImageLoader(fn string, vocab map[string]int64, trans *transforms.ComposeTransformer, mbSize int) (*ImageLoader, error) {
+	r, e := tgz.OpenFile(fn)
+	if e != nil {
+		return nil, e
+	}
+	return &ImageLoader{
+		r:      r,
+		vocab:  vocab,
+		err:    nil,
+		trans:  trans,
+		mbSize: mbSize,
+	}, nil
+}
+
+// Scan return false if no more dat
+func (p *ImageLoader) Scan() bool {
+	if p.err == io.EOF {
+		return false
+	}
+	if p.err != nil {
+		return false
+	}
+	p.tensorGC()
+	p.retreiveMinibatch()
+	return true
+}
+
+func (p *ImageLoader) retreiveMinibatch() {
+	for {
+		hdr, err := p.r.Next()
+		if err != nil {
+			p.err = err
+			break
+		}
+		if !hdr.FileInfo().Mode().IsRegular() {
+			continue
+		}
+		classStr := filepath.Base(filepath.Dir(hdr.Name))
+		label := p.vocab[classStr]
+		p.labels = append(p.labels, label)
+
+		m, _, err := image.Decode(p.r)
+		if err != nil {
+			p.err = err
+			break
+		}
+		input := p.trans.Run(m)
+		p.inputs = append(p.inputs, input.(torch.Tensor))
+
+		if len(p.inputs) == p.mbSize {
+			break
+		}
+	}
+}
+
+// Minibatch returns a minibash with data and label Tensor
+func (p *ImageLoader) Minibatch() (torch.Tensor, torch.Tensor) {
+	return torch.Stack(p.inputs, 0), torch.NewTensor(p.labels)
+}
+
+// Err returns the error during the scan process, if there is any. io.EOF is not
+// considered an error.
+func (p *ImageLoader) Err() error {
+	if p.err == io.EOF {
+		return nil
+	}
+	return p.err
+}
+
+// BuildLabelVocabularyFromTgz build a label vocabulary from the image tgz file
+func BuildLabelVocabularyFromTgz(fn string) (map[string]int64, error) {
+	vocab := make(map[string]int64)
+	l, e := tgz.ListFile(fn)
+	if e != nil {
+		return nil, e
+	}
+	idx := 0
+	for _, hdr := range l {
+		class := filepath.Base(filepath.Dir(hdr.Name))
+		if _, ok := vocab[class]; !ok {
+			vocab[class] = int64(idx)
+			idx++
+		}
+	}
+	return vocab, nil
+}

--- a/vision/datasets/imageloader_test.go
+++ b/vision/datasets/imageloader_test.go
@@ -1,0 +1,45 @@
+package datasets
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/wangkuiyi/gotorch/tool/tgz"
+	"github.com/wangkuiyi/gotorch/vision/transforms"
+)
+
+func TestImageTgzLoader(t *testing.T) {
+	a := assert.New(t)
+	d, e := ioutil.TempDir("", "gotorch_tarball_divide_test*")
+	a.NoError(e)
+
+	fn := tgz.SynthesizeTarball(t, d)
+	expectedVocab := map[string]int64{"0": int64(0), "1": int64(1)}
+	vocab, e := BuildLabelVocabularyFromTgz(fn)
+	a.NoError(e)
+	a.Equal(expectedVocab, vocab)
+
+	trans := transforms.Compose(
+		transforms.ToTensor(),
+		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
+	)
+	loader, e := NewImageLoader(fn, vocab, trans, 3)
+	a.NoError(e)
+	{
+		// first iteration
+		a.True(loader.Scan())
+		data, label := loader.Minibatch()
+		a.Equal([]int64{3, 3, 2, 2}, data.Shape())
+		a.Equal([]int64{3}, label.Shape())
+	}
+	{
+		// second iteration with minibatch size is 2
+		a.True(loader.Scan())
+		data, label := loader.Minibatch()
+		a.Equal([]int64{2, 3, 2, 2}, data.Shape())
+		a.Equal([]int64{2}, label.Shape())
+	}
+	// no more data at the third iteration
+	a.False(loader.Scan())
+}


### PR DESCRIPTION
This PR implements an `ImageLoader` relying on the `tool/tgz` package and verifies it with the MNIST dataset.
The `ImageLoader` accepts a `.tgz` file which contains many image files and provides a convenient interface to read the minibatch.

I rewrite the MNIST dataset because it's small and fast to verify, and I will also rewrite the ImageNet dataloader with `ImageLoader` in the future.
