### PR TITLE
fix build with CUDA

### DIFF
--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -22,6 +22,7 @@ if [[ "$OS" == "linux" ]]; then
             unzip -qq -o libtorch-rpi-cxx11-abi-shared-1.6.0.zip -d rpi
         fi
     elif $(whereis cuda | cut -f 2 -d ' ')/bin/nvcc --version > /dev/null; then
+        CXX="clang++"
         CUDA_VERSION=`nvcc --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1`
         if [[ "$CUDA_VERSION" == "10.1" ]]; then
             echo "Building for Linux with CUDA 10.1";


### PR DESCRIPTION
the libcgotorch.so can link the `libtorch_cuda` correctly.

``` text
$ ldd libcgotorch.so
	linux-vdso.so.1 (0x00007ffdafbf9000)
	libc10.so => /work/gotorch/cgotorch/libtorch/lib/libc10.so (0x00007f9456b96000)
	libtorch.so => /work/gotorch/cgotorch/libtorch/lib/libtorch.so (0x00007f9456994000)
	libtorch_cpu.so => /work/gotorch/cgotorch/libtorch/lib/libtorch_cpu.so (0x00007f944646e000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f94460de000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f9445d40000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f9445b28000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f9445735000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f945705f000)
	libgomp-75eea7e8.so.1 => /work/gotorch/cgotorch/libtorch/lib/libgomp-75eea7e8.so.1 (0x00007f9445510000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f94452f1000)
	libtorch_cuda.so => /work/gotorch/cgotorch/libtorch/lib/libtorch_cuda.so (0x00007f940e7b2000)
        ....
```