### PR TITLE
Fix a segment fault

### DIFF
--- a/nn/functional/functional.go
+++ b/nn/functional/functional.go
@@ -95,8 +95,8 @@ func ConvTranspose2d(
 		(*C.int64_t)(unsafe.Pointer(&dilation[0])),
 		C.int64_t(len(dilation)),
 		&t)))
-	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	runtime.KeepAlive(input.T)
+	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
 

--- a/nn/functional/functional.go
+++ b/nn/functional/functional.go
@@ -7,6 +7,7 @@ package functional
 import "C"
 
 import (
+	"runtime"
 	"unsafe"
 
 	torch "github.com/wangkuiyi/gotorch"
@@ -43,6 +44,7 @@ func BatchNorm(input, runningMean, runningVar, weight, bias torch.Tensor,
 			C.double(momentum),
 			C.double(eps),
 			&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -63,6 +65,7 @@ func Conv2d(input, weight, bias torch.Tensor,
 		(*C.int64_t)(unsafe.Pointer(&dilation[0])), C.int64_t(len(dilation)),
 		C.int64_t(groups),
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -93,6 +96,7 @@ func ConvTranspose2d(
 		C.int64_t(len(dilation)),
 		&t)))
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
+	runtime.KeepAlive(input.T)
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
 
@@ -123,6 +127,7 @@ func NllLoss(input, target, weight torch.Tensor, ignoreIndex int64,
 		C.int64_t(ignoreIndex),
 		C.CString(reduction),
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -140,6 +145,7 @@ func BinaryCrossEntropy(input, target, weight torch.Tensor,
 		cweight,
 		C.CString(reduction),
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -158,6 +164,7 @@ func CrossEntropy(input, target, weight torch.Tensor, ignoreIndex int64,
 		C.int64_t(ignoreIndex),
 		C.CString(reduction),
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -171,6 +178,7 @@ func Relu(input torch.Tensor, inplace bool) torch.Tensor {
 	}
 	torch.MustNil(unsafe.Pointer(C.FRelu(
 		C.Tensor(*input.T), C.int8_t(cInplace), &t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -184,6 +192,7 @@ func LeakyRelu(input torch.Tensor, negativeSlope float64, inplace bool) torch.Te
 	}
 	torch.MustNil(unsafe.Pointer(C.FLeakyRelu(C.Tensor(*input.T),
 		C.double(negativeSlope), C.int8_t(cInplace), &t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -198,6 +207,7 @@ func Linear(input, weight, bias torch.Tensor) torch.Tensor {
 	torch.MustNil(unsafe.Pointer(C.Linear(
 		C.Tensor(*input.T),
 		C.Tensor(*weight.T), cBias, &t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -218,6 +228,7 @@ func MaxPool2d(input torch.Tensor, kernelSize, stride, padding,
 		(*C.int64_t)(unsafe.Pointer(&dilation[0])), C.int64_t(len(dilation)),
 		cMode,
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }
@@ -229,6 +240,7 @@ func AdaptiveAvgPool2d(input torch.Tensor, outputSize []int64) torch.Tensor {
 		C.Tensor(*input.T),
 		(*C.int64_t)(unsafe.Pointer(&outputSize[0])), C.int64_t(len(outputSize)),
 		&t)))
+	runtime.KeepAlive(input.T)
 	torch.SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return torch.Tensor{(*unsafe.Pointer)(&t)}
 }


### PR DESCRIPTION
Without `KeepAlive`, Go's "smart" GC may recycle `unsafe.Pointer`'s during a Cgo call. This may cause the following problem:
```
tal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0xe0 pc=0x7f53ea44d8ec]

runtime stack:
runtime.throw(0x59f772, 0x2a)
        /usr/local/go/src/runtime/panic.go:774 +0x72
runtime.sigpanic()
        /usr/local/go/src/runtime/signal_unix.go:378 +0x47c

goroutine 1 [syscall, 2 minutes]:
runtime.cgocall(0x53b000, 0xc0000c1938, 0xc000010728)
        /usr/local/go/src/runtime/cgocall.go:128 +0x5b fp=0xc0000c1908 sp=0xc0000c18d0 pc=0x407a3b
github.com/wangkuiyi/gotorch/nn/functional._Cfunc_BatchNorm(0x198bd50, 0x19146a0, 0x1938720, 0x189bfe0, 0x1941490, 0xc0000c1901, 0x3fb999999999999a, 0x3ee4f8b588e368f1, 0xc000010728, 0x0)
        _cgo_gotypes.go:91 +0x4e fp=0xc0000c1938 sp=0xc0000c1908 pc=0x52fdde
github.com/wangkuiyi/gotorch/nn/functional.BatchNorm.func1(0xc000010720, 0x19146a0, 0x1938720, 0x189bfe0, 0x1941490, 0x532401, 0x3fb999999999999a, 0x3ee4f8b588e368f1, 0xc000010728, 0xc000077e50)
        /go/src/github.com/wangkuiyi/gotorch/nn/functional/functional.go:45 +0x1ee fp=0xc0000c19a0 sp=0xc0000c1938 pc=0x530bde
github.com/wangkuiyi/gotorch/nn/functional.BatchNorm(0xc000010720, 0xc000010268, 0xc000010270, 0xc000010258, 0xc000010260, 0x1, 0x3fb999999999999a, 0x3ee4f8b588e368f1, 0xc000077e50)
        /go/src/github.com/wangkuiyi/gotorch/nn/functional/functional.go:45 +0xd6 fp=0xc0000c1a08 sp=0xc0000c19a0 pc=0x5304e6
github.com/wangkuiyi/gotorch/nn.(*BatchNorm2dModule).Forward(0xc00009a4d0, 0xc000010720, 0xc000010720)
        /go/src/github.com/wangkuiyi/gotorch/nn/batchnorm.go:73 +0x89 fp=0xc0000c1a60 sp=0xc0000c1a08 pc=0x5317e9
github.com/wangkuiyi/gotorch/vision/models.(*BasicBlockModule).Forward(0xc0000821e0, 0xc000010708, 0x0)
        /go/src/github.com/wangkuiyi/gotorch/vision/models/resnet.go:39 +0x5e fp=0xc0000c1ab8 sp=0xc0000c1a60 pc=0x536c0e
runtime.call32(0xc000072390, 0xc000010718, 0xc00000e740, 0x1000000018)
        /usr/local/go/src/runtime/asm_amd64.s:539 +0x3b fp=0xc0000c1ae8 sp=0xc0000c1ab8 pc=0x459edb
reflect.Value.call(0x585a00, 0xc0000821e0, 0xa13, 0x597537, 0x4, 0xc00000e720, 0x1, 0x1, 0x0, 0x58fde0, ...)
        /usr/local/go/src/reflect/value.go:460 +0x5f6 fp=0xc0000c1d08 sp=0xc0000c1ae8 pc=0x487756
reflect.Value.Call(0x585a00, 0xc0000821e0, 0xa13, 0xc00000e720, 0x1, 0x1, 0xc0000821e0, 0xa13, 0x3)
        /usr/local/go/src/reflect/value.go:321 +0xb4 fp=0xc0000c1d88 sp=0xc0000c1d08 pc=0x486f14
github.com/wangkuiyi/gotorch/nn.(*SequentialModule).Forward(0xc000054180, 0xc0000c1ed8, 0x1, 0x1, 0x58fde0, 0xc000010708)
        /go/src/github.com/wangkuiyi/gotorch/nn/container.go:28 +0x153 fp=0xc0000c1e38 sp=0xc0000c1d88 pc=0x531973
github.com/wangkuiyi/gotorch/vision/models.(*ResnetModule).Forward(0xc00009c000, 0xc000010520, 0xc000010528)
        /go/src/github.com/wangkuiyi/gotorch/vision/models/resnet.go:192 +0x3f1 fp=0xc0000c1ef8 sp=0xc0000c1e38 pc=0x5384b1
main.main()
        /go/src/github.com/wangkuiyi/gotorch/example/resnet/resnet2.go:43 +0x116 fp=0xc0000c1f60 sp=0xc0000c1ef8 pc=0x539656
runtime.main()
        /usr/local/go/src/runtime/proc.go:203 +0x21e fp=0xc0000c1fe0 sp=0xc0000c1f60 pc=0x43322e
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0000c1fe8 sp=0xc0000c1fe0 pc=0x45bbf1
```