### PR TITLE
support pin memory option in data loader

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -232,6 +232,7 @@ const char *Tensor_To(Tensor input, Device device, int8_t dtype,
                       Tensor *output);
 const char *Tensor_CastTo(Tensor input, int8_t dtype, Tensor *output);
 const char *Tensor_CopyTo(Tensor input, Device device, Tensor *output);
+const char *Tensor_PinMemory(Tensor input, Tensor *output);
 
 ////////////////////////////////////////////////////////////////////////////////
 //  Dataset, DataLoader, and Iterator torch.utils.data

--- a/cgotorch/tensor.cc
+++ b/cgotorch/tensor.cc
@@ -148,6 +148,16 @@ const char *Tensor_CopyTo(Tensor input, Device device, Tensor *output) {
   }
 }
 
+const char *Tensor_PinMemory(Tensor input, Tensor *output) {
+  try {
+    auto result = input->pin_memory();
+    *output = new at::Tensor(result);
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 // Backward, Gradient
 void Tensor_Backward(Tensor a) { a->backward(); }
 Tensor Tensor_Grad(Tensor a) { return new at::Tensor(a->grad()); }

--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -99,7 +99,7 @@ func celebaLoader(data string, vocab map[string]int, mbSize int) *datasets.Image
 		transforms.CenterCrop(imageSize),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.5, 0.5, 0.5}, []float64{0.5, 0.5, 0.5}))
-	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, true)
+	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, false)
 	if e != nil {
 		panic(e)
 	}

--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -99,7 +99,7 @@ func celebaLoader(data string, vocab map[string]int, mbSize int) *datasets.Image
 		transforms.CenterCrop(imageSize),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.5, 0.5, 0.5}, []float64{0.5, 0.5, 0.5}))
-	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize)
+	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, true)
 	if e != nil {
 		panic(e)
 	}

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -93,7 +93,7 @@ func train(trainFn, testFn string, epochs int, save string) {
 // MNISTLoader returns a ImageLoader with MNIST training or testing tgz file
 func MNISTLoader(fn string, vocab map[string]int) *datasets.ImageLoader {
 	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float64{0.1307}, []float64{0.3081}))
-	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64)
+	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64, false)
 	if e != nil {
 		panic(e)
 	}

--- a/tensor.go
+++ b/tensor.go
@@ -130,6 +130,9 @@ func (a Tensor) CopyTo(device Device) Tensor {
 
 // PinMemory returns a tensor in pinned memory. Pinned memory requires CUDA.
 func (a Tensor) PinMemory() Tensor {
+	if !IsCUDAAvailable() {
+		return a
+	}
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Tensor_PinMemory(C.Tensor(*a.T), &t)))
 	SetTensorFinalizer((*unsafe.Pointer)(&t))

--- a/tensor.go
+++ b/tensor.go
@@ -128,6 +128,14 @@ func (a Tensor) CopyTo(device Device) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
+// PinMemory returns a tensor in pinned memory
+func (a Tensor) PinMemory() Tensor {
+	var t C.Tensor
+	MustNil(unsafe.Pointer(C.Tensor_PinMemory(C.Tensor(*a.T), &t)))
+	SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return Tensor{(*unsafe.Pointer)(&t)}
+}
+
 // SetData sets the tensor data held by b to a
 func (a Tensor) SetData(b Tensor) {
 	MustNil(unsafe.Pointer(C.Tensor_SetData(C.Tensor(*a.T), C.Tensor(*b.T))))

--- a/tensor.go
+++ b/tensor.go
@@ -128,7 +128,7 @@ func (a Tensor) CopyTo(device Device) Tensor {
 	return Tensor{(*unsafe.Pointer)(&t)}
 }
 
-// PinMemory returns a tensor in pinned memory
+// PinMemory returns a tensor in pinned memory. Pinned memory requires CUDA.
 func (a Tensor) PinMemory() Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Tensor_PinMemory(C.Tensor(*a.T), &t)))

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -113,3 +113,9 @@ func TestTensorIndex(t *testing.T) {
 	assert.Panics(t, func() { a.Index(0).Item() })
 	assert.Panics(t, func() { a.Index(0, 0, 0).Item() })
 }
+
+func TestTensorPinMemory(t *testing.T) {
+	a := torch.NewTensor([][]float32{{1, 2}, {3, 4}})
+	b := a.PinMemory()
+	t.Log(b)
+}

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -67,12 +67,6 @@ func TestCopyTo(t *testing.T) {
 	assert.True(t, torch.Equal(a, b))
 }
 
-func TestPinMemory(t *testing.T) {
-	a := torch.NewTensor([]int64{1, 2})
-	b := a.PinMemory()
-	assert.True(t, torch.Equal(a, b))
-}
-
 func TestDim(t *testing.T) {
 	a := torch.RandN([]int64{2, 3}, false)
 	assert.Equal(t, int64(2), a.Dim())

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -68,7 +68,6 @@ func TestCopyTo(t *testing.T) {
 }
 
 func TestPinMemory(t *testing.T) {
-	device := torch.NewDevice("cpu")
 	a := torch.NewTensor([]int64{1, 2})
 	b := a.PinMemory()
 	assert.True(t, torch.Equal(a, b))

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -67,6 +67,13 @@ func TestCopyTo(t *testing.T) {
 	assert.True(t, torch.Equal(a, b))
 }
 
+func TestPinMemory(t *testing.T) {
+	device := torch.NewDevice("cpu")
+	a := torch.NewTensor([]int64{1, 2})
+	b := a.PinMemory()
+	assert.True(t, torch.Equal(a, b))
+}
+
 func TestDim(t *testing.T) {
 	a := torch.RandN([]int64{2, 3}, false)
 	assert.Equal(t, int64(2), a.Dim())

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -117,5 +117,9 @@ func TestTensorIndex(t *testing.T) {
 func TestTensorPinMemory(t *testing.T) {
 	a := torch.NewTensor([][]float32{{1, 2}, {3, 4}})
 	b := a.PinMemory()
-	t.Log(b)
+	if torch.IsCUDAAvailable() {
+		assert.Equal(t, " 1  2\n 3  4\n[ CUDAFloatType{2,2} ]", b.String())
+	} else {
+		assert.Equal(t, " 1  2\n 3  4\n[ CPUFloatType{2,2} ]", b.String())
+	}
 }

--- a/vision/datasets/imageloader_test.go
+++ b/vision/datasets/imageloader_test.go
@@ -43,7 +43,7 @@ func TestImageTgzLoaderError(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
 	)
-	loader, e := NewImageLoader(f.Name(), vocab, trans, 3)
+	loader, e := NewImageLoader(f.Name(), vocab, trans, 3, false)
 	a.NoError(e)
 	a.False(loader.Scan())
 	a.Error(loader.Err())
@@ -64,7 +64,7 @@ func TestImageTgzLoader(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
 	)
-	loader, e := NewImageLoader(fn, vocab, trans, 3)
+	loader, e := NewImageLoader(fn, vocab, trans, 3, false)
 	a.NoError(e)
 	{
 		// first iteration
@@ -108,7 +108,7 @@ func TestImageTgzLoaderHeavy(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
 
-	loader, e := NewImageLoader(trainFn, vocab, trans, mbSize)
+	loader, e := NewImageLoader(trainFn, vocab, trans, mbSize, false)
 	if e != nil {
 		log.Fatal(e)
 	}


### PR DESCRIPTION
It seems that the pin_memory option does influence throughput.


Set pin_memory to false:

```bash
go run resnet.go -data=/work/imagenet_training_shuffled.tar.gz -test=/work/imagenet_testing_shuffled.tar.gz -save=/work/imagenet_model.gob -pin_memory=false
```

```text
2020/09/09 04:37:22 CUDA is valid
2020/09/09 04:37:22 building label vocabulary done.
2020/09/09 04:37:30 Train Epoch: 0, Iteration: 10, loss:13.632916, acc1: 87.500000, acc5:100.000000, throughput: 69.852786 samples/sec
2020/09/09 04:37:35 Test average loss: 1.4146 acc1: 1.7981 acc5: 1.9394
2020/09/09 04:37:40 Train Epoch: 1, Iteration: 10, loss:0.003742, acc1: 100.000000, acc5:100.000000, throughput: 70.061571 samples/sec
2020/09/09 04:37:45 Test average loss: 0.4674 acc1: 1.7981 acc5: 3.2663
2020/09/09 04:37:49 Train Epoch: 2, Iteration: 10, loss:4.226585, acc1: 18.750000, acc5:100.000000, throughput: 69.678877 samples/sec
2020/09/09 04:37:54 Test average loss: 0.1191 acc1: 1.7981 acc5: 3.2663
2020/09/09 04:37:58 Train Epoch: 3, Iteration: 10, loss:3.212929, acc1: 93.750000, acc5:100.000000, throughput: 70.401655 samples/sec
2020/09/09 04:38:03 Test average loss: 0.0881 acc1: 1.7566 acc5: 3.2663
2020/09/09 04:38:08 Train Epoch: 4, Iteration: 10, loss:0.606939, acc1: 100.000000, acc5:100.000000, throughput: 69.899359 samples/sec
2020/09/09 04:38:13 Test average loss: 0.0711 acc1: 1.7981 acc5: 3.2663
```

Set pin_memory to true:

```bash
go run resnet.go -data=/work/imagenet_training_shuffled.tar.gz -test=/work/imagenet_testing_shuffled.tar.gz -save=/work/imagenet_model.gob -pin_memory=true
```

```text
2020/09/09 04:38:50 CUDA is valid
2020/09/09 04:38:50 building label vocabulary done.
2020/09/09 04:38:59 Train Epoch: 0, Iteration: 10, loss:24.770842, acc1: 0.000000, acc5:100.000000, throughput: 68.620483 samples/sec
2020/09/09 04:39:04 Test average loss: 0.9708 acc1: 1.7981 acc5: 3.2663
2020/09/09 04:39:08 Train Epoch: 1, Iteration: 10, loss:0.020655, acc1: 100.000000, acc5:100.000000, throughput: 70.079330 samples/sec
2020/09/09 04:39:13 Test average loss: 0.1176 acc1: 1.7902 acc5: 3.2663
2020/09/09 04:39:18 Train Epoch: 2, Iteration: 10, loss:3.236537, acc1: 96.875000, acc5:100.000000, throughput: 69.939865 samples/sec
2020/09/09 04:39:23 Test average loss: 0.1242 acc1: 1.7981 acc5: 3.2663
2020/09/09 04:39:27 Train Epoch: 3, Iteration: 10, loss:2.985363, acc1: 3.125000, acc5:100.000000, throughput: 69.427791 samples/sec
2020/09/09 04:39:32 Test average loss: 0.0668 acc1: 1.7981 acc5: 3.2663
2020/09/09 04:39:37 Train Epoch: 4, Iteration: 10, loss:2.462174, acc1: 96.875000, acc5:100.000000, throughput: 70.031448 samples/sec
2020/09/09 04:39:41 Test average loss: 0.0554 acc1: 1.7981 acc5: 3.2663
```


Besides, when setting pin_memory true, it crashes randomly:

```text
2020/09/09 04:57:06 CUDA is valid
2020/09/09 04:57:07 building label vocabulary done.
true
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x7feb48bd5dac]

runtime stack:
runtime.throw(0x5c4682, 0x2a)
	/usr/local/go/src/runtime/panic.go:1116 +0x72
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:679 +0x46a

goroutine 1 [syscall]:
runtime.cgocall(0x560020, 0xc0002e5ca0, 0xc000332030)
	/usr/local/go/src/runtime/cgocall.go:133 +0x5b fp=0xc0002e5c70 sp=0xc0002e5c38 pc=0x407e2b
github.com/wangkuiyi/gotorch._Cfunc_Tensor_PinMemory(0x7fea4c000ce0, 0xc000332030, 0x0)
	_cgo_gotypes.go:1157 +0x4e fp=0xc0002e5ca0 sp=0xc0002e5c70 pc=0x50558e
github.com/wangkuiyi/gotorch.Tensor.PinMemory.func1(0xc0000100e0, 0xc000332030, 0xc00019c0d0)
	/work/gotorch/tensor.go:134 +0x9f fp=0xc0002e5cd8 sp=0xc0002e5ca0 pc=0x509a8f
github.com/wangkuiyi/gotorch.Tensor.PinMemory(0xc0000100e0, 0xc0001b2008)
	/work/gotorch/tensor.go:134 +0x45 fp=0xc0002e5d08 sp=0xc0002e5cd8 pc=0x5068b5
github.com/wangkuiyi/gotorch/vision/datasets.(*ImageLoader).Minibatch(0xc000113980, 0x1, 0xc00019ac60)
	/work/gotorch/vision/datasets/imageloader.go:121 +0x12b fp=0xc0002e5d78 sp=0xc0002e5d08 pc=0x555bbb
main.train(0x7ffd63da45ea, 0x27, 0x7ffd63da4618, 0x26, 0x7ffd63da4645, 0x18, 0x5, 0xc000199501)
	/work/gotorch/example/resnet/resnet.go:151 +0x20d fp=0xc0002e5f00 sp=0xc0002e5d78 pc=0x55ef8d
main.main()
	/work/gotorch/example/resnet/resnet.go:199 +0x310 fp=0xc0002e5f88 sp=0xc0002e5f00 pc=0x55fb10
runtime.main()
	/usr/local/go/src/runtime/proc.go:203 +0x1fa fp=0xc0002e5fe0 sp=0xc0002e5f88 pc=0x439b4a
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0002e5fe8 sp=0xc0002e5fe0 pc=0x4645c1
```

