### PR TITLE
Small dedup

### DIFF
--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -99,7 +99,7 @@ func celebaLoader(data string, vocab map[string]int, mbSize int) *datasets.Image
 		transforms.CenterCrop(imageSize),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.5, 0.5, 0.5}, []float64{0.5, 0.5, 0.5}))
-	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, false)
+	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)
 	}

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -93,7 +93,7 @@ func train(trainFn, testFn string, epochs int, save string) {
 // MNISTLoader returns a ImageLoader with MNIST training or testing tgz file
 func MNISTLoader(fn string, vocab map[string]int) *datasets.ImageLoader {
 	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float64{0.1307}, []float64{0.3081}))
-	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64, false)
+	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)
 	}

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -196,5 +196,5 @@ func main() {
 
 	flag.Parse()
 
-	train(*trainTar, *testTar, *save, *epochs, *pinMemory)
+	train(*trainTar, *testTar, *save, *epochs, *pinMemory && torch.IsCUDAAvailable())
 }

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -67,12 +67,6 @@ func TestCopyTo(t *testing.T) {
 	assert.True(t, torch.Equal(a, b))
 }
 
-func TestPinMemory(t *testing.T) {
-	a := torch.NewTensor([]int64{1, 2})
-	b := a.PinMemory()
-	assert.True(t, torch.Equal(a, b))
-}
-
 func TestDim(t *testing.T) {
 	a := torch.RandN([]int64{2, 3}, false)
 	assert.Equal(t, int64(2), a.Dim())

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -68,7 +68,6 @@ func TestCopyTo(t *testing.T) {
 }
 
 func TestPinMemory(t *testing.T) {
-	device := torch.NewDevice("cpu")
 	a := torch.NewTensor([]int64{1, 2})
 	b := a.PinMemory()
 	assert.True(t, torch.Equal(a, b))

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -67,6 +67,13 @@ func TestCopyTo(t *testing.T) {
 	assert.True(t, torch.Equal(a, b))
 }
 
+func TestPinMemory(t *testing.T) {
+	device := torch.NewDevice("cpu")
+	a := torch.NewTensor([]int64{1, 2})
+	b := a.PinMemory()
+	assert.True(t, torch.Equal(a, b))
+}
+
 func TestDim(t *testing.T) {
 	a := torch.RandN([]int64{2, 3}, false)
 	assert.Equal(t, int64(2), a.Dim())

--- a/tool/tgz/synthesize.go
+++ b/tool/tgz/synthesize.go
@@ -4,12 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
-	"image"
 	"image/color"
-	"image/draw"
 	"image/png"
 	"path/filepath"
 	"strings"
+
+	"github.com/wangkuiyi/gotorch/vision"
 )
 
 // SynthesizeTarball generates a tarball file.
@@ -49,7 +49,7 @@ func Synthesize(w *Writer) error {
 	}
 
 	var buf bytes.Buffer
-	img := drawImage(image.Rect(0, 0, 2, 2), color.RGBA{0, 0, 255, 255})
+	img := vision.SynthesizeImage(2, 2, color.RGBA{0, 0, 255, 255})
 	if e := png.Encode(&buf, img); e != nil {
 		return fmt.Errorf("Failed encoding PNG file: %v", e)
 	}
@@ -82,10 +82,4 @@ func Synthesize(w *Writer) error {
 	}
 
 	return nil
-}
-
-func drawImage(size image.Rectangle, c color.Color) image.Image {
-	m := image.NewRGBA(size)
-	draw.Draw(m, m.Bounds(), &image.Uniform{c}, image.ZP, draw.Src)
-	return m
 }

--- a/vision/synthesizer.go
+++ b/vision/synthesizer.go
@@ -1,4 +1,4 @@
-package datasets
+package vision
 
 import (
 	"archive/tar"

--- a/vision/synthesizer_test.go
+++ b/vision/synthesizer_test.go
@@ -1,4 +1,4 @@
-package datasets_test
+package vision_test
 
 import (
 	"archive/tar"
@@ -9,11 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision"
 )
 
 func synthesizeImages(w io.Writer) []string {
-	s := datasets.NewSynthesizer(w)
+	s := vision.NewSynthesizer(w)
 	defer s.Close()
 	colors := []color.Color{
 		color.RGBA{0, 0, 255, 255},


### PR DESCRIPTION
The function `drawImage` in `tools/tgz/*.test` duplicates with `vision/dataloader.SynthesizeImage`.

It also follows up the PinMemory PR to make data loaders to return records in pinned memory if there is CUDA.