### PR TITLE
port Clone method

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -105,11 +105,13 @@ void FreeString(const char *s);
 const char *Tensor_Save(Tensor tensor, const char *path);
 const char *Tensor_Load(const char *path, Tensor *result);
 const char *Tensor_Dim(Tensor tensor, int64_t *dim);
+const char *Tensor_Numel(Tensor tensor, int64_t *numel);
 const char *Tensor_Shape(Tensor tensor, int64_t *dims);
 const char *Tensor_Dtype(Tensor tensor, int8_t *dtype);
 const char *Tensor_SetData(Tensor self, Tensor new_data);
 const char *Tensor_FromBlob(void *data, int8_t dtype, int64_t *sizes_data,
                             int64_t sizes_data_len, Tensor *result);
+const char *Tensor_Clone(Tensor tensor, Tensor *result);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Get elements

--- a/cgotorch/tensor.cc
+++ b/cgotorch/tensor.cc
@@ -87,6 +87,15 @@ const char *Tensor_Dim(Tensor tensor, int64_t *dim) {
   }
 }
 
+const char *Tensor_Numel(Tensor tensor, int64_t *numel) {
+  try {
+    *numel = tensor->numel();
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
 const char *Tensor_Shape(Tensor tensor, int64_t *dims) {
   try {
     int i = 0;
@@ -173,13 +182,22 @@ const char *Tensor_SetData(Tensor self, Tensor new_data) {
 
 // from_blob does not allocate a new space, it returns a C++ tensor view
 // of a Go array. When the array in Go world is freed, the tensor in C++
-// world becomes illegal. We must switch to use deep copy.
+// world becomes illegal.
 const char *Tensor_FromBlob(void *data, int8_t dtype, int64_t *sizes_data,
                             int64_t sizes_data_len, Tensor *result) {
   try {
     auto t = at::from_blob(data, at::IntArrayRef(sizes_data, sizes_data_len),
-                           torch::dtype(at::ScalarType(dtype)))
-                 .clone();
+                           torch::dtype(at::ScalarType(dtype)));
+    *result = new at::Tensor(t);
+    return nullptr;
+  } catch (const std::exception &e) {
+    return exception_str(e.what());
+  }
+}
+
+const char *Tensor_Clone(Tensor tensor, Tensor *result) {
+  try {
+    auto t = tensor->clone();
     *result = new at::Tensor(t);
     return nullptr;
   } catch (const std::exception &e) {

--- a/tensor.go
+++ b/tensor.go
@@ -68,6 +68,13 @@ func (a Tensor) Dim() int64 {
 	return dim
 }
 
+// Numel tensor.numel
+func (a Tensor) Numel() int64 {
+	var numel int64
+	MustNil(unsafe.Pointer(C.Tensor_Numel(C.Tensor(*a.T), (*C.int64_t)(&numel))))
+	return numel
+}
+
 // Shape returns shape
 func (a Tensor) Shape() []int64 {
 	shape := make([]int64, a.Dim())
@@ -150,7 +157,7 @@ func To(a Tensor, device Device, dtype int8) Tensor {
 	return a.To(device, dtype)
 }
 
-// FromBlob returns a deep copy Tensor with the given data memory
+// FromBlob returns a Tensor view of the given data memory
 func FromBlob(data unsafe.Pointer, dtype int8, sizes []int64) Tensor {
 	var t C.Tensor
 	MustNil(unsafe.Pointer(C.Tensor_FromBlob(
@@ -158,6 +165,16 @@ func FromBlob(data unsafe.Pointer, dtype int8, sizes []int64) Tensor {
 		C.int8_t(dtype),
 		(*C.int64_t)(unsafe.Pointer(&sizes[0])),
 		C.int64_t(len(sizes)),
+		&t)))
+	SetTensorFinalizer((*unsafe.Pointer)(&t))
+	return Tensor{(*unsafe.Pointer)(&t)}
+}
+
+// Clone returns a new Tensor
+func (a Tensor) Clone() Tensor {
+	var t C.Tensor
+	MustNil(unsafe.Pointer(C.Tensor_Clone(
+		C.Tensor(*a.T),
 		&t)))
 	SetTensorFinalizer((*unsafe.Pointer)(&t))
 	return Tensor{(*unsafe.Pointer)(&t)}

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -25,6 +25,17 @@ func TestFromBlob(t *testing.T) {
 	assert.Equal(t, []int64{2, 3}, out.Shape())
 }
 
+func TestClone(t *testing.T) {
+	a := torch.NewTensor([]int64{1, 2})
+	b := a.Clone()
+	assert.True(t, torch.Equal(a, b))
+}
+
+func TestNumel(t *testing.T) {
+	x := torch.RandN([]int64{3, 4}, true)
+	assert.Equal(t, int64(12), x.Numel())
+}
+
 func TestTensorString(t *testing.T) {
 	data := [2][3]float32{{1.0, 1.1, 1.2}, {2, 3, 4}}
 	out := torch.FromBlob(unsafe.Pointer(&data), torch.Float, []int64{2, 3})

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -26,9 +26,16 @@ func TestFromBlob(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	a := torch.NewTensor([]int64{1, 2})
+	data := []float32{2.0}
+	a := torch.FromBlob(unsafe.Pointer(&data[0]), torch.Float, []int64{1})
 	b := a.Clone()
-	assert.True(t, torch.Equal(a, b))
+
+	assert.Equal(t, float32(2.0), a.Item().(float32))
+	assert.Equal(t, float32(2.0), b.Item().(float32))
+
+	data[0] = 1.0
+	assert.Equal(t, float32(1.0), a.Item().(float32))
+	assert.Equal(t, float32(2.0), b.Item().(float32))
 }
 
 func TestNumel(t *testing.T) {

--- a/vision/datasets/imageloader.go
+++ b/vision/datasets/imageloader.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"io"
 	"path/filepath"
+	"unsafe"
 
 	torch "github.com/wangkuiyi/gotorch"
 	tgz "github.com/wangkuiyi/gotorch/tool/tgz"
@@ -114,7 +115,7 @@ func (p *ImageLoader) retreiveMinibatch() bool {
 // Minibatch returns a minibash with data and label Tensor
 func (p *ImageLoader) Minibatch() (torch.Tensor, torch.Tensor) {
 	i := torch.Stack(p.inputs, 0)
-	l := torch.NewTensor(p.labels)
+	l := torch.FromBlob(unsafe.Pointer(&p.labels[0]), torch.Long, []int64{int64(len(p.labels))})
 	if p.pinMemory {
 		return i.PinMemory(), l.PinMemory()
 	}

--- a/vision/transforms/to_tensor.go
+++ b/vision/transforms/to_tensor.go
@@ -58,7 +58,7 @@ func colorImageToTensor(img image.Image) torch.Tensor {
 		}
 	}
 	hwc := torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float,
-		[]int64{int64(maxY), int64(maxX), 3})
+		[]int64{int64(maxY), int64(maxX), 3}).Clone()
 	return hwc.Permute([]int64{2, 0, 1})
 }
 
@@ -77,11 +77,11 @@ func grayImageToTensor(img image.Image) torch.Tensor {
 		}
 	}
 	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Float,
-		[]int64{int64(maxY), int64(maxX)})
+		[]int64{int64(maxY), int64(maxX)}).Clone()
 }
 
 func intToTensor(x int) torch.Tensor {
 	array := make([]int32, 1)
 	array[0] = int32(x)
-	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Int, []int64{1})
+	return torch.FromBlob(unsafe.Pointer(&array[0]), torch.Int, []int64{1}).Clone()
 }


### PR DESCRIPTION
This PR makes `FromBlob` the same semantic(Tensor View) with libtorch, and exposes the `Clone` method.

And I find that `NewTensor` will create another temporary Go slice.  Once the temporary slice is freed, the torch Tensor will be illegal. 

So, I use `FromBlob` in image data loader instead of `NewTensor`. The `p.labels` is held by the data loader, so, it will not be freed. It's  safe to use `FromBlob`, but not safe to use `NewTensor` here.

