### PR TITLE
Rename `vision/datasets` to `vision/imageloader`

### DIFF
--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -14,7 +14,7 @@ import (
 	nn "github.com/wangkuiyi/gotorch/nn"
 	F "github.com/wangkuiyi/gotorch/nn/functional"
 	"github.com/wangkuiyi/gotorch/nn/initializer"
-	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/imageloader"
 	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
@@ -93,13 +93,13 @@ func discriminator(nc int64, ndf int64) *nn.SequentialModule {
 	)
 }
 
-func celebaLoader(data string, vocab map[string]int, mbSize int) *datasets.ImageLoader {
+func celebaLoader(data string, vocab map[string]int, mbSize int) *imageloader.ImageLoader {
 	imageSize := 64
 	trans := transforms.Compose(transforms.Resize(imageSize),
 		transforms.CenterCrop(imageSize),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.5, 0.5, 0.5}, []float64{0.5, 0.5, 0.5}))
-	loader, e := datasets.NewImageLoader(data, vocab, trans, mbSize, torch.IsCUDAAvailable())
+	loader, e := imageloader.New(data, vocab, trans, mbSize, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)
 	}
@@ -142,7 +142,7 @@ func main() {
 	optimizerG := torch.Adam(lr, 0.5, 0.999, 0.0)
 	optimizerG.AddParameters(netG.Parameters())
 
-	vocab, e := datasets.BuildLabelVocabularyFromTgz(*data)
+	vocab, e := imageloader.BuildLabelVocabularyFromTgz(*data)
 	if e != nil {
 		log.Fatal(e)
 	}

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -14,7 +14,7 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 	F "github.com/wangkuiyi/gotorch/nn/functional"
 	"github.com/wangkuiyi/gotorch/nn/initializer"
-	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/imageloader"
 	"github.com/wangkuiyi/gotorch/vision/models"
 	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
@@ -57,7 +57,7 @@ func main() {
 }
 
 func train(trainFn, testFn string, epochs int, save string) {
-	vocab, e := datasets.BuildLabelVocabularyFromTgz(trainFn)
+	vocab, e := imageloader.BuildLabelVocabularyFromTgz(trainFn)
 	if e != nil {
 		panic(e)
 	}
@@ -91,16 +91,16 @@ func train(trainFn, testFn string, epochs int, save string) {
 }
 
 // MNISTLoader returns a ImageLoader with MNIST training or testing tgz file
-func MNISTLoader(fn string, vocab map[string]int) *datasets.ImageLoader {
+func MNISTLoader(fn string, vocab map[string]int) *imageloader.ImageLoader {
 	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float64{0.1307}, []float64{0.3081}))
-	loader, e := datasets.NewImageLoader(fn, vocab, trans, 64, torch.IsCUDAAvailable())
+	loader, e := imageloader.New(fn, vocab, trans, 64, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)
 	}
 	return loader
 }
 
-func test(model *models.MLPModule, loader *datasets.ImageLoader) {
+func test(model *models.MLPModule, loader *imageloader.ImageLoader) {
 	testLoss := float32(0)
 	correct := int64(0)
 	samples := 0

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -16,12 +16,7 @@ import (
 	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
 
-// the original Imagenet dataset contains 1281167 training images
-// c.f. https://patrykchrabaszcz.github.io/Imagenet32/
-const (
-	trainSamples = 1281167
-	logInterval  = 10 // in iterations
-)
+const logInterval = 10 // in iterations
 
 var device torch.Device
 

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -11,7 +11,7 @@ import (
 	torch "github.com/wangkuiyi/gotorch"
 	F "github.com/wangkuiyi/gotorch/nn/functional"
 	"github.com/wangkuiyi/gotorch/nn/initializer"
-	"github.com/wangkuiyi/gotorch/vision/datasets"
+	"github.com/wangkuiyi/gotorch/vision/imageloader"
 	"github.com/wangkuiyi/gotorch/vision/models"
 	"github.com/wangkuiyi/gotorch/vision/transforms"
 )
@@ -73,14 +73,14 @@ func accuracy(output, target torch.Tensor, topk []int64) []float32 {
 	return res
 }
 
-func imageNetLoader(fn string, vocab map[string]int, mbSize int, pinMemory bool) *datasets.ImageLoader {
+func imageNetLoader(fn string, vocab map[string]int, mbSize int, pinMemory bool) *imageloader.ImageLoader {
 	trans := transforms.Compose(
 		transforms.RandomResizedCrop(224),
 		transforms.RandomHorizontalFlip(0.5),
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
 
-	loader, e := datasets.NewImageLoader(fn, vocab, trans, mbSize, pinMemory)
+	loader, e := imageloader.New(fn, vocab, trans, mbSize, pinMemory)
 	if e != nil {
 		log.Fatal(e)
 	}
@@ -98,7 +98,7 @@ func trainOneMinibatch(image, target torch.Tensor, model *models.ResnetModule, o
 	return loss.Item().(float32), acc1, acc5
 }
 
-func test(model *models.ResnetModule, loader *datasets.ImageLoader) {
+func test(model *models.ResnetModule, loader *imageloader.ImageLoader) {
 	testLoss := float32(0)
 	acc1 := float32(0)
 	acc5 := float32(0)
@@ -124,7 +124,7 @@ func test(model *models.ResnetModule, loader *datasets.ImageLoader) {
 
 func train(trainFn, testFn, save string, epochs int, pinMemory bool) {
 	// build label vocabulary
-	vocab, e := datasets.BuildLabelVocabularyFromTgz(trainFn)
+	vocab, e := imageloader.BuildLabelVocabularyFromTgz(trainFn)
 	if e != nil {
 		log.Fatal(e)
 	}

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -1,4 +1,4 @@
-package datasets
+package imageloader
 
 import (
 	"image"
@@ -30,8 +30,8 @@ type ImageLoader struct {
 	pinMemory bool
 }
 
-// NewImageLoader returns an ImageLoader
-func NewImageLoader(fn string, vocab map[string]int, trans *transforms.ComposeTransformer,
+// New returns an ImageLoader
+func New(fn string, vocab map[string]int, trans *transforms.ComposeTransformer,
 	mbSize int, pinMemory bool) (*ImageLoader, error) {
 	r, e := tgz.OpenFile(fn)
 	if e != nil {

--- a/vision/imageloader/imageloader_test.go
+++ b/vision/imageloader/imageloader_test.go
@@ -1,4 +1,4 @@
-package datasets
+package imageloader
 
 import (
 	"archive/tar"
@@ -43,7 +43,7 @@ func TestImageTgzLoaderError(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
 	)
-	loader, e := NewImageLoader(f.Name(), vocab, trans, 3, false)
+	loader, e := New(f.Name(), vocab, trans, 3, false)
 	a.NoError(e)
 	a.False(loader.Scan())
 	a.Error(loader.Err())
@@ -64,7 +64,7 @@ func TestImageTgzLoader(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
 	)
-	loader, e := NewImageLoader(fn, vocab, trans, 3, false)
+	loader, e := New(fn, vocab, trans, 3, false)
 	a.NoError(e)
 	{
 		// first iteration
@@ -108,7 +108,7 @@ func TestImageTgzLoaderHeavy(t *testing.T) {
 		transforms.ToTensor(),
 		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
 
-	loader, e := NewImageLoader(trainFn, vocab, trans, mbSize, false)
+	loader, e := New(trainFn, vocab, trans, mbSize, false)
 	if e != nil {
 		log.Fatal(e)
 	}


### PR DESCRIPTION
The package name `datasets` is not exactly, I renamed it to `imageloader` because it provides APIs to load the image TGZ file.
