### PR TITLE
Build as no CUDA with unknown CUDA version

### DIFF
--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -13,9 +13,20 @@ LOAD="force_load"
 LIB_SUFFIX="so"
 INSTALL_NAME=""
 
+function build_linux_no_cuda() {
+	CXX="clang++"
+        LIBTORCH_DIR="linux/libtorch"
+        GLIBCXX_USE_CXX11_ABI="0"
+        if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
+            curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.6.0%2Bcpu.zip'
+            unzip -qq -o libtorch-shared-with-deps-1.6.0%2Bcpu.zip -d linux
+        fi
+}
+
 if [[ "$OS" == "linux" ]]; then
     if [[ "$ARCH" =~ arm* ]]; then
         echo "Building for Raspbian ...";
+	CXX="g++"
         LIBTORCH_DIR="rpi/libtorch"
         if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
             curl -LsO 'https://github.com/ljk53/pytorch-rpi/raw/master/libtorch-rpi-cxx11-abi-shared-1.6.0.zip';
@@ -23,7 +34,8 @@ if [[ "$OS" == "linux" ]]; then
         fi
     elif $(whereis cuda | cut -f 2 -d ' ')/bin/nvcc --version > /dev/null; then
         CXX="clang++"
-        CUDA_VERSION=`nvcc --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1`
+	NVCC=$(whereis cuda | cut -f 2 -d ' ')/bin/nvcc
+        CUDA_VERSION=$("$NVCC" --version | grep release | grep -Eo "[0-9]+.[0-9]+" | head -1)
         if [[ "$CUDA_VERSION" == "10.1" ]]; then
             echo "Building for Linux with CUDA 10.1";
             LIBTORCH_DIR="linux-cuda101/libtorch"
@@ -38,18 +50,17 @@ if [[ "$OS" == "linux" ]]; then
                 curl -Lso libtorch-cxx11-1.6.0-linux-cuda102.zip 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.6.0.zip'
                 unzip -qq -o libtorch-cxx11-1.6.0-linux-cuda102.zip -d linux-cuda102
             fi
+	else
+	    echo "Unknown CUDA version: $CUDA_VERSION"
+	    build_linux_no_cuda
         fi
     else
         echo "Building for Linux without CUDA ...";
-        LIBTORCH_DIR="linux/libtorch"
-        GLIBCXX_USE_CXX11_ABI="0"
-        if [[ ! -d "$DIR/$LIBTORCH_DIR" ]]; then
-            curl -LsO 'https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.6.0%2Bcpu.zip'
-            unzip -qq -o libtorch-shared-with-deps-1.6.0%2Bcpu.zip -d linux
-        fi
+	build_linux_no_cuda
     fi
 elif [[ "$OS" == "darwin" ]]; then
     echo "Building for macOS ...";
+    CXX="clang++"
     LIBTORCH_DIR="macos/libtorch"
     LIB_SUFFIX="dylib"
     INSTALL_NAME="-install_name @rpath/\$@"
@@ -60,12 +71,12 @@ elif [[ "$OS" == "darwin" ]]; then
     fi
 fi
 
+set -o xtrace
 make CXX="$CXX" \
      LIB_SUFFIX="$LIB_SUFFIX" \
      INSTALL_NAME="$INSTALL_NAME" \
      LIBTORCH_DIR="$LIBTORCH_DIR" \
      GLIBCXX_USE_CXX11_ABI="$GLIBCXX_USE_CXX11_ABI" \
-     LOAD="$LOAD" \
-     -f Makefile;
+     LOAD="$LOAD"
 
 popd


### PR DESCRIPTION
Without this change, when we run `cgotorch/build.sh` on a Linux compute with an unsupported CUDA version, it doesn't set the environment variables required by Makefile.

This change handles the case by considering it as no CUDA.