### PR TITLE
Typo fixes

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -29,7 +29,7 @@ libtorch.
 1. The finest-grained layer is in libtorch -- about 1600 native functions, each
    is a fundamental operation in mathematics or its corresponding gradient
    operation.  Each native function has CPU and GPU implementations. By linking
-   libtorch with [XLA](github.com/pytorch/xla), we get an additional
+   libtorch with [XLA](https://github.com/pytorch/xla), we get an additional
    implementation for Google TPU.
 
 1. A higher-level abstraction is in the Python package `torch.nn.functional`,

--- a/doc/design_cn.md
+++ b/doc/design_cn.md
@@ -15,7 +15,7 @@ GoTorch使用Go语言封装了libtorch。libtorch是PyTorch的C++核心，它有
 总的来说，PyTorch提供了三层API：
 
 1. 最细粒度的一层是libtorch中的原生函数(native functions)，约有1600个。原生函数或者是一个数学上的基本运算，或者是相应的梯度计算。
-   每个原生函数都有GPU和CPU两种实现，libtorch可以和[XLA](github.com/pytorch/xla)链接到一起，从而获得Google TPU上的原生函数实现。
+   每个原生函数都有GPU和CPU两种实现，libtorch可以和[XLA](https://github.com/pytorch/xla)链接到一起，从而获得Google TPU上的原生函数实现。
 
 1. `torch.nn.functional`这个Python包提供了更高一级的抽象，这个包用纯Python封装了C++原生函数，更符合Python用户的使用习惯。
 


### PR DESCRIPTION
The link without `https://` in the doc will lead to https://github.com/wangkuiyi/gotorch/blob/develop/doc/github.com/pytorch/xla