### PR TITLE
use float32 in Normalize Transform

### DIFF
--- a/doc/design_cn.md
+++ b/doc/design_cn.md
@@ -15,7 +15,8 @@ GoTorch使用Go语言封装了libtorch。libtorch是PyTorch的C++核心，它有
 总的来说，PyTorch提供了三层API：
 
 1. 最细粒度的一层是libtorch中的原生函数(native functions)，约有1600个。原生函数或者是一个数学上的基本运算，或者是相应的梯度计算。
-   每个原生函数都有GPU和CPU两种实现，libtorch可以和[XLA](https://github.com/pytorch/xla)链接到一起，从而获得Google TPU上的原生函数实现。
+   每个原生函数都有GPU和CPU两种实现，libtorch可以
+   和[XLA](https://github.com/pytorch/xla)链接到一起，从而获得Google TPU上的原生函数实现。
 
 1. `torch.nn.functional`这个Python包提供了更高一级的抽象，这个包用纯Python封装了C++原生函数，更符合Python用户的使用习惯。
 

--- a/example/dcgan/dcgan.go
+++ b/example/dcgan/dcgan.go
@@ -98,7 +98,7 @@ func celebaLoader(data string, vocab map[string]int, mbSize int) *imageloader.Im
 	trans := transforms.Compose(transforms.Resize(imageSize),
 		transforms.CenterCrop(imageSize),
 		transforms.ToTensor(),
-		transforms.Normalize([]float64{0.5, 0.5, 0.5}, []float64{0.5, 0.5, 0.5}))
+		transforms.Normalize([]float32{0.5, 0.5, 0.5}, []float32{0.5, 0.5, 0.5}))
 	loader, e := imageloader.New(data, vocab, trans, mbSize, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -92,7 +92,7 @@ func train(trainFn, testFn string, epochs int, save string) {
 
 // MNISTLoader returns a ImageLoader with MNIST training or testing tgz file
 func MNISTLoader(fn string, vocab map[string]int) *imageloader.ImageLoader {
-	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float64{0.1307}, []float64{0.3081}))
+	trans := transforms.Compose(transforms.ToTensor(), transforms.Normalize([]float32{0.1307}, []float32{0.3081}))
 	loader, e := imageloader.New(fn, vocab, trans, 64, torch.IsCUDAAvailable())
 	if e != nil {
 		panic(e)
@@ -181,6 +181,6 @@ func predictFile(fn string, m *models.MLPModule) {
 	}
 
 	t := transforms.ToTensor().Run(img)
-	n := transforms.Normalize([]float64{0.1307}, []float64{0.3081}).Run(t)
+	n := transforms.Normalize([]float32{0.1307}, []float32{0.3081}).Run(t)
 	fmt.Println(m.Forward(n).Argmax().Item())
 }

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -73,7 +73,7 @@ func imageNetLoader(fn string, vocab map[string]int, mbSize int, pinMemory bool)
 		transforms.RandomResizedCrop(224),
 		transforms.RandomHorizontalFlip(0.5),
 		transforms.ToTensor(),
-		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
+		transforms.Normalize([]float32{0.485, 0.456, 0.406}, []float32{0.229, 0.224, 0.225}))
 
 	loader, e := imageloader.New(fn, vocab, trans, mbSize, pinMemory)
 	if e != nil {

--- a/vision/imageloader/imageloader_test.go
+++ b/vision/imageloader/imageloader_test.go
@@ -41,7 +41,7 @@ func TestImageTgzLoaderError(t *testing.T) {
 	vocab := map[string]int{"0": 0, "1": 1}
 	trans := transforms.Compose(
 		transforms.ToTensor(),
-		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
+		transforms.Normalize([]float32{0.1307}, []float32{0.3081}),
 	)
 	loader, e := New(f.Name(), vocab, trans, 3, false)
 	defer torch.FinishGC()
@@ -62,7 +62,7 @@ func TestImageTgzLoader(t *testing.T) {
 	a.Equal(expectedVocab, vocab)
 	trans := transforms.Compose(
 		transforms.ToTensor(),
-		transforms.Normalize([]float64{0.1307}, []float64{0.3081}),
+		transforms.Normalize([]float32{0.1307}, []float32{0.3081}),
 	)
 	loader, e := New(fn, vocab, trans, 3, false)
 	defer torch.FinishGC()
@@ -107,7 +107,7 @@ func TestImageTgzLoaderHeavy(t *testing.T) {
 		transforms.RandomResizedCrop(224),
 		transforms.RandomHorizontalFlip(0.5),
 		transforms.ToTensor(),
-		transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
+		transforms.Normalize([]float32{0.485, 0.456, 0.406}, []float32{0.229, 0.224, 0.225}))
 
 	loader, e := New(trainFn, vocab, trans, mbSize, false)
 	defer torch.FinishGC()
@@ -134,7 +134,7 @@ func TestSplitComposeByToTensor(t *testing.T) {
 			transforms.RandomResizedCrop(224),
 			transforms.RandomHorizontalFlip(0.5),
 			transforms.ToTensor(),
-			transforms.Normalize([]float64{0.485, 0.456, 0.406}, []float64{0.229, 0.224, 0.225}))
+			transforms.Normalize([]float32{0.485, 0.456, 0.406}, []float32{0.229, 0.224, 0.225}))
 		trans1, trans2 := splitComposeByToTensor(trans)
 		a.Equal(len(trans1.Transforms), 2)
 		_, ok := trans1.Transforms[0].(*transforms.RandomResizedCropTransformer)

--- a/vision/transforms/normalize.go
+++ b/vision/transforms/normalize.go
@@ -13,20 +13,20 @@ type NormalizeTransformer struct {
 }
 
 // Normalize returns normalize transformer
-func Normalize(mean []float64, stddev []float64) *NormalizeTransformer {
+func Normalize(mean []float32, stddev []float32) *NormalizeTransformer {
 	var meanT torch.Tensor
 	var stddevT torch.Tensor
 	if len(mean) == 1 {
-		meanT = torch.NewTensor([][][]float64{{{mean[0]}}})
+		meanT = torch.NewTensor([][][]float32{{{mean[0]}}})
 	} else if len(mean) == 3 {
-		meanT = torch.NewTensor([][][]float64{{{mean[0]}}, {{mean[1]}}, {{mean[2]}}})
+		meanT = torch.NewTensor([][][]float32{{{mean[0]}}, {{mean[1]}}, {{mean[2]}}})
 	} else {
 		panic(fmt.Sprintf("len(Mean) should be 1 or 3."))
 	}
 	if len(stddev) == 1 {
-		stddevT = torch.NewTensor([][][]float64{{{stddev[0]}}})
+		stddevT = torch.NewTensor([][][]float32{{{stddev[0]}}})
 	} else if len(stddev) == 3 {
-		stddevT = torch.NewTensor([][][]float64{{{stddev[0]}}, {{stddev[1]}}, {{stddev[2]}}})
+		stddevT = torch.NewTensor([][][]float32{{{stddev[0]}}, {{stddev[1]}}, {{stddev[2]}}})
 	} else {
 		panic(fmt.Sprintf("len(Stddev) should be 1 or 3."))
 	}
@@ -35,9 +35,8 @@ func Normalize(mean []float64, stddev []float64) *NormalizeTransformer {
 
 // Run normalize the input (Tensor) of size (C, H, W) using the stats value mean, stddev.
 func (t *NormalizeTransformer) Run(input torch.Tensor) torch.Tensor {
-	dtype := input.Dtype()
 	// TODO(typhoonzero): check if stddevT equals 0
 	x := input.Sub(t.mean, 1.0)
-	x = x.Div(t.stddev).CastTo(dtype)
+	x = x.Div(t.stddev)
 	return x
 }

--- a/vision/transforms/normalize_test.go
+++ b/vision/transforms/normalize_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestNormalizeTransform(t *testing.T) {
 	a := assert.New(t)
-	trans := Normalize([]float64{10.0}, []float64{2.3})
-	t1 := torch.NewTensor([]float64{10.2, 11.3, 9.2})
+	trans := Normalize([]float32{10.0}, []float32{2.3})
+	t1 := torch.NewTensor([]float32{10.2, 11.3, 9.2})
 	t2 := trans.Run(t1)
 
-	expected := torch.NewTensor([]float64{
+	expected := torch.NewTensor([]float32{
 		(10.2 - 10.0) / 2.3,
 		(11.3 - 10.0) / 2.3,
 		(9.2 - 10.0) / 2.3})
@@ -21,12 +21,12 @@ func TestNormalizeTransform(t *testing.T) {
 }
 func TestNormalizeTransform3D(t *testing.T) {
 	a := assert.New(t)
-	trans := Normalize([]float64{1.0, 2.0, 3.0}, []float64{2.3, 2.4, 2.5})
+	trans := Normalize([]float32{1.0, 2.0, 3.0}, []float32{2.3, 2.4, 2.5})
 	// an image in torch should be a 3D tensor with CHW format
-	t1 := torch.NewTensor([][][]float64{{{10.2}}, {{11.3}}, {{9.2}}})
+	t1 := torch.NewTensor([][][]float32{{{10.2}}, {{11.3}}, {{9.2}}})
 	t2 := trans.Run(t1)
 
-	expected := torch.NewTensor([][][]float64{
+	expected := torch.NewTensor([][][]float32{
 		{{(10.2 - 1.0) / 2.3}},
 		{{(11.3 - 2.0) / 2.4}},
 		{{(9.2 - 3.0) / 2.5}}})
@@ -37,12 +37,12 @@ func TestNormalizeTransformPanic(t *testing.T) {
 	a := assert.New(t)
 	// mean and stddev should be 1 or 3 dims
 	a.Panics(func() {
-		trans := Normalize([]float64{1.0, 2.0, 3.0, 4.0, 5.0}, []float64{2.3, 2.4, 2.5})
-		trans.Run(torch.NewTensor([]float64{1.0}))
+		trans := Normalize([]float32{1.0, 2.0, 3.0, 4.0, 5.0}, []float32{2.3, 2.4, 2.5})
+		trans.Run(torch.NewTensor([]float32{1.0}))
 	})
 	a.Panics(func() {
-		trans := Normalize([]float64{1.0, 2.0, 3.0}, []float64{2.3, 2.4})
-		trans.Run(torch.NewTensor([]float64{1.0}))
+		trans := Normalize([]float32{1.0, 2.0, 3.0}, []float32{2.3, 2.4})
+		trans.Run(torch.NewTensor([]float32{1.0}))
 	})
 
 }


### PR DESCRIPTION
The input tensor has float32 type.  float64 mean and std in NormalizeTransform introduce unnecessary data cast.