### PR TITLE
GC only wait for tensors generated by the main goroutine

### DIFF
--- a/cgotorch/cgotorch.h
+++ b/cgotorch/cgotorch.h
@@ -247,6 +247,14 @@ const char *CUDA_GetCUDAStreamFromPool(CUDAStream *stream, Device *device);
 const char *CUDA_Synchronize(CUDAStream stream);
 const char *CUDA_Query(CUDAStream stream, int8_t *result);
 
+////////////////////////////////////////////////////////////////////////////////
+//  Memory management for Go garbage collector
+////////////////////////////////////////////////////////////////////////////////
+
+uint8_t GCPrepared();
+void PrepareGC();
+void FinishGC();
+
 #ifdef __cplusplus
 }
 #endif

--- a/cgotorch/memory.cc
+++ b/cgotorch/memory.cc
@@ -4,7 +4,7 @@
 // FIXME(shendiaomo): including cgotorch.h before torch/torch.h will fail
 #include "cgotorch/cgotorch.h"
 
-thread_local bool gcPrepared;
+thread_local bool gcPrepared = false;
 
 uint8_t GCPrepared() { return gcPrepared; }
 

--- a/cgotorch/memory.cc
+++ b/cgotorch/memory.cc
@@ -1,6 +1,6 @@
-#include "torch/torch.h"
+// Copyright 2020, GoTorch Authors
 #include "cgotorch/cgotorch.h"
-
+#include "torch/torch.h"
 
 thread_local bool gcPrepared;
 

--- a/cgotorch/memory.cc
+++ b/cgotorch/memory.cc
@@ -1,0 +1,11 @@
+#include "torch/torch.h"
+#include "cgotorch/cgotorch.h"
+
+
+thread_local bool gcPrepared;
+
+uint8_t GCPrepared() { return gcPrepared; }
+
+void PrepareGC() { gcPrepared = true; }
+
+void FinishGC() { gcPrepared = false; }

--- a/cgotorch/memory.cc
+++ b/cgotorch/memory.cc
@@ -1,6 +1,8 @@
 // Copyright 2020, GoTorch Authors
-#include "cgotorch/cgotorch.h"
 #include "torch/torch.h"
+
+// FIXME(shendiaomo): including cgotorch.h before torch/torch.h will fail
+#include "cgotorch/cgotorch.h"
 
 thread_local bool gcPrepared;
 

--- a/tensor_gc.go
+++ b/tensor_gc.go
@@ -15,6 +15,43 @@ var (
 	tensorFinalizersWG = &sync.WaitGroup{}
 )
 
+// GoTorch should allow goroutines other than the main goroutine to create
+// tensors whose lifecycle last for more than one iteration, for example, we
+// have to cache tensors in data loading goroutines because they run faster.
+
+// To meet this goal, we have to make sure a `torch.GC()` function call in the
+// main goroutine know which tensors are created by the main goroutine, and only
+// wait for tensors created in the main goroutine to be freed.
+
+// Actually, we need a "goroutine local storage" mechanism to distinguish the
+// main goroutine and the data loading goroutine. However, Go doesn't provide
+// an official "goroutine local storage", and the official `context` package
+// will impose additional parameters to user API, thus make the API harder to
+// use.
+
+// Recall that we've already locked the main goroutine to a fixed OS thread in
+// the `init` function in device.go, we can use a C++ `thread_local` to solve
+// the problem.
+
+// The three functions `C.GCPrepared()`, `C.PrepareGC()`, and `C.FinishGC()` are
+// defined in cgotorch/memory.cc, they use the C++ variable
+// `thread_local bool gcPrepared`
+// to help control the behavior of the function `torch.GC()` as described above.
+
+// Known limitation:
+// 1. `torch.GC()` should be called in only one goroutine in a GoTorch program
+//    (typically the main goroutine) exactly before the training/testing loop
+//    starts. If we call `torch.GC()` in a unit test case, we have to call
+//    `runtime.LockOSThread` manually because the `go test` cmd tool will start
+//    new goroutines to run the cases.
+// 2. `torch.FinishGC()` should only be called in the same goroutine as the
+//    `torch.GC()` function exactly after a training/testing loop ends. Or the
+//    goroutine may hang forever.
+
+// In general, `torch.GC()` and `torch.FinishGC()` are low-level functions that
+// ordinary users don't have to care about. GoTorch provides high-level APIs
+// that wraps the two functions.
+
 // SetTensorFinalizer sets a finalizer to the tensor
 func SetTensorFinalizer(t *unsafe.Pointer) {
 	// We don't want the following conditional and the finalizer using

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -161,6 +161,6 @@ func TestTensorGC(t *testing.T) {
 		}()
 	}
 	<-c
-	assert.Eventually(t, func() bool { torch.GC(); return true }, time.Millisecond, time.Microsecond)
+	assert.Eventually(t, func() bool { torch.GC(); return true }, 2*time.Millisecond, 10*time.Microsecond)
 
 }

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -149,6 +149,7 @@ func TestTensorPinMemory(t *testing.T) {
 
 func TestTensorGC(t *testing.T) {
 	torch.GC()
+	defer torch.FinishGC()
 	runtime.LockOSThread()
 	c := make(chan torch.Tensor, 0)
 	{

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -150,17 +150,16 @@ func TestTensorPinMemory(t *testing.T) {
 func TestTensorGC(t *testing.T) {
 	torch.GC()
 	runtime.LockOSThread()
-	c := make(chan bool, 0)
+	c := make(chan torch.Tensor, 0)
 	{
 		torch.NewTensor([][]float32{{1, 2}, {3, 4}})
 		go func() {
 			a := torch.NewTensor([][]float32{{1, 2}, {3, 4}})
-			c <- true
+			c <- a
 			time.Sleep(time.Second)
 			runtime.KeepAlive(&a)
 		}()
 	}
 	<-c
 	assert.Eventually(t, func() bool { torch.GC(); return true }, 2*time.Millisecond, 10*time.Microsecond)
-
 }

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -161,5 +161,5 @@ func TestTensorGC(t *testing.T) {
 		}()
 	}
 	<-c
-	assert.Eventually(t, func() bool { torch.GC(); return true }, 2*time.Millisecond, 10*time.Microsecond)
+	assert.Eventually(t, func() bool { torch.GC(); return true }, 10*time.Millisecond, 10*time.Microsecond)
 }

--- a/tensor_test.go
+++ b/tensor_test.go
@@ -3,7 +3,9 @@ package gotorch_test
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
@@ -143,4 +145,22 @@ func TestTensorPinMemory(t *testing.T) {
 	} else {
 		assert.Equal(t, " 1  2\n 3  4\n[ CPUFloatType{2,2} ]", b.String())
 	}
+}
+
+func TestTensorGC(t *testing.T) {
+	torch.GC()
+	runtime.LockOSThread()
+	c := make(chan bool, 0)
+	{
+		torch.NewTensor([][]float32{{1, 2}, {3, 4}})
+		go func() {
+			a := torch.NewTensor([][]float32{{1, 2}, {3, 4}})
+			c <- true
+			time.Sleep(time.Second)
+			runtime.KeepAlive(&a)
+		}()
+	}
+	<-c
+	assert.Eventually(t, func() bool { torch.GC(); return true }, time.Millisecond, time.Microsecond)
+
 }


### PR DESCRIPTION
Use `thread_local` and `runtime.LockOSThread()` together to make sure that `runtime.GC()` only waits for tensors created by the main goroutine to be reclaimed.

This is to enable the `ImageLoader` to do more work in the background goroutines.

Fix #343 