### PR TITLE
use ReadFull instead of Read

### DIFF
--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -101,7 +101,7 @@ func (p *ImageLoader) read() {
 		classStr := filepath.Base(filepath.Dir(hdr.Name))
 		label := p.vocab[classStr]
 		buffer := make([]byte, hdr.Size)
-		p.r.Read(buffer)
+		io.ReadFull(p.r, buffer)
 		var m gocv.Mat
 		if p.colorSpace == RGB {
 			m, err = gocv.IMDecode(buffer, gocv.IMReadColor)


### PR DESCRIPTION
Fix #346 

```txt
Read reads data into p. It returns the number of bytes read into p. 
The bytes are taken from at most one Read on the underlying Reader, hence n may be less than len(p).
To read exactly len(p) bytes, use io.ReadFull(b, p). At EOF, the count will be zero and err will be io.EOF.
```