### PR TITLE
Improve ImageLoader performance

### DIFF
--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -156,14 +156,11 @@ func train(trainFn, testFn, label, save string, epochs int, pinMemory bool) {
 				throughput := float64(data.Shape()[0]*logInterval) / time.Since(startTime).Seconds()
 				log.Printf("Train Epoch: %d, Iteration: %d, loss:%f, acc1: %f, acc5:%f, throughput: %f samples/sec", epoch, iter, loss, acc1, acc5, throughput)
 				startTime = time.Now()
-				break
 			}
 		}
-		break
 		test(model, testLoader)
 	}
-	torch.FinishGC()
-	//saveModel(model, save)
+	saveModel(model, save)
 }
 
 func loadLabel(labelFn string) map[string]int {

--- a/example/resnet/resnet.go
+++ b/example/resnet/resnet.go
@@ -141,13 +141,12 @@ func train(trainFn, testFn, label, save string, epochs int, pinMemory bool) {
 	mbSize := 32
 	optimizer := torch.SGD(lr, momentum, 0, weightDecay, false)
 	optimizer.AddParameters(model.Parameters())
-
 	for epoch := 0; epoch < epochs; epoch++ {
 		adjustLearningRate(optimizer, epoch, lr)
-		startTime := time.Now()
 		trainLoader := imageNetLoader(trainFn, vocab, mbSize, pinMemory)
 		testLoader := imageNetLoader(testFn, vocab, mbSize, pinMemory)
 		iter := 0
+		startTime := time.Now()
 		for trainLoader.Scan() {
 			iter++
 			data, label := trainLoader.Minibatch()
@@ -157,11 +156,14 @@ func train(trainFn, testFn, label, save string, epochs int, pinMemory bool) {
 				throughput := float64(data.Shape()[0]*logInterval) / time.Since(startTime).Seconds()
 				log.Printf("Train Epoch: %d, Iteration: %d, loss:%f, acc1: %f, acc5:%f, throughput: %f samples/sec", epoch, iter, loss, acc1, acc5, throughput)
 				startTime = time.Now()
+				break
 			}
 		}
+		break
 		test(model, testLoader)
 	}
-	saveModel(model, save)
+	torch.FinishGC()
+	//saveModel(model, save)
 }
 
 func loadLabel(labelFn string) map[string]int {

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -128,7 +128,10 @@ func (p *ImageLoader) readSample() {
 func (p *ImageLoader) readMinibatch() {
 	inputs := []gocv.Mat{}
 	labels := []int64{}
-	defer close(p.mbChan)
+	defer func() {
+		close(p.mbChan)
+		close(p.errChan)
+	}()
 	for {
 		sample, ok := <-p.sampleChan
 		if !ok {

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -13,6 +13,11 @@ import (
 	"gocv.io/x/gocv"
 )
 
+type sample struct {
+	data  gocv.Mat
+	label int64
+}
+
 type miniBatch struct {
 	data  torch.Tensor
 	label torch.Tensor
@@ -28,6 +33,7 @@ const GRAY string = "gray"
 type ImageLoader struct {
 	r          *tgz.Reader
 	vocab      map[string]int
+	sampleChan chan sample
 	mbChan     chan miniBatch
 	errChan    chan error
 	err        error
@@ -51,6 +57,7 @@ func New(fn string, vocab map[string]int, trans *transforms.ComposeTransformer,
 	m := &ImageLoader{
 		r:          r,
 		vocab:      vocab,
+		sampleChan: make(chan sample, mbSize*4),
 		mbChan:     make(chan miniBatch, 4),
 		errChan:    make(chan error, 1),
 		trans1:     trans1,
@@ -60,7 +67,8 @@ func New(fn string, vocab map[string]int, trans *transforms.ComposeTransformer,
 		colorSpace: colorSpace,
 	}
 	runtime.LockOSThread()
-	go m.read()
+	go m.readSample()
+	go m.readMinibatch()
 	return m, nil
 }
 
@@ -85,19 +93,17 @@ func (p *ImageLoader) Scan() bool {
 	return false
 }
 
-func (p *ImageLoader) read() {
-	inputs := []gocv.Mat{}
-	labels := []int64{}
-
+func (p *ImageLoader) readSample() {
 	defer func() {
-		close(p.mbChan)
-		close(p.errChan)
+		close(p.sampleChan)
 	}()
 
 	for {
 		hdr, err := p.r.Next()
 		if err != nil {
-			p.errChan <- err
+			if err != io.EOF {
+				p.errChan <- err
+			}
 			break
 		}
 		if !hdr.FileInfo().Mode().IsRegular() {
@@ -115,8 +121,22 @@ func (p *ImageLoader) read() {
 		if m.Empty() {
 			panic("read invalid image content!")
 		}
-		inputs = append(inputs, p.trans1.Run(m).(gocv.Mat))
-		labels = append(labels, int64(label))
+		p.sampleChan <- sample{p.trans1.Run(m).(gocv.Mat), int64(label)}
+	}
+}
+
+func (p *ImageLoader) readMinibatch() {
+	inputs := []gocv.Mat{}
+	labels := []int64{}
+	defer close(p.mbChan)
+	for {
+		sample, ok := <-p.sampleChan
+		if !ok {
+			p.errChan <- io.EOF
+			break
+		}
+		inputs = append(inputs, sample.data)
+		labels = append(labels, sample.label)
 		if len(inputs) == p.mbSize {
 			p.mbChan <- p.collateMiniBatch(inputs, labels)
 			inputs = []gocv.Mat{}


### PR DESCRIPTION
As the pprof shows as the figure, `readImage` and `collateMinibatch` takes up the most of the running time of `read`, this PR overlapped them to improve the `ImageLoader` performance.
![image](https://user-images.githubusercontent.com/1426912/94005277-a286f580-fdd0-11ea-9c7c-d39e10b00577.png)

The following shows the optimization result:

## `TestImageTgzLoaderHeavy` unit test

`160 samples/sec` to `200 samples /secs` on `TestImageTgzLoaderHeavy` which looping`ImageLoader` without  any `forward` execution.
Before:
 ``` text
2020/09/23 17:55:07 throughput: 164.325665 samples/secs
2020/09/23 17:55:09 throughput: 155.669797 samples/secs
2020/09/23 17:55:11 throughput: 159.222238 samples/secs
2020/09/23 17:55:13 throughput: 173.701349 samples/secs
2020/09/23 17:55:15 throughput: 169.121735 samples/secs
2020/09/23 17:55:17 throughput: 159.841330 samples/secs
```

After:
``` text
2020/09/23 18:44:46 throughput: 217.233734 samples/secs
2020/09/23 18:44:48 throughput: 200.534489 samples/secs
2020/09/23 18:44:50 throughput: 186.947048 samples/secs
2020/09/23 18:44:51 throughput: 216.004914 samples/secs
```
## `ResNet50` with small batchsize equals to 32

No significant improvement. 

## `ResNet` with batchsize equals to 128

``` 160 samples/secs``` to ```190 samples/secs ``` on ResNet50 training with the minibatch size equals to 128.

Before:
``` text
2020/09/23 11:11:24 building label vocabulary done.
2020/09/23 11:11:36 Train Epoch: 0, Iteration: 10, loss:8.990389, acc1: 0.000000, acc5:0.781250, throughput: 147.494557 samples/sec
2020/09/23 11:11:44 Train Epoch: 0, Iteration: 20, loss:7.615139, acc1: 0.000000, acc5:1.562500, throughput: 167.828753 samples/sec
2020/09/23 11:11:52 Train Epoch: 0, Iteration: 30, loss:7.598644, acc1: 0.000000, acc5:0.000000, throughput: 164.928037 samples/sec
2020/09/23 11:11:59 Train Epoch: 0, Iteration: 40, loss:7.041448, acc1: 0.000000, acc5:0.000000, throughput: 164.891008 samples/sec
2020/09/23 11:12:07 Train Epoch: 0, Iteration: 50, loss:6.979727, acc1: 0.000000, acc5:0.781250, throughput: 160.888822 samples/sec
2020/09/23 11:12:15 Train Epoch: 0, Iteration: 60, loss:6.934577, acc1: 0.000000, acc5:0.781250, throughput: 159.259985 samples/sec
```

After:
``` text
2020/09/23 11:10:08 building label vocabulary done.
2020/09/23 11:10:20 Train Epoch: 0, Iteration: 10, loss:8.582557, acc1: 0.000000, acc5:0.000000, throughput: 167.261230 samples/sec
2020/09/23 11:10:26 Train Epoch: 0, Iteration: 20, loss:7.519489, acc1: 0.781250, acc5:3.125000, throughput: 199.541734 samples/sec
2020/09/23 11:10:33 Train Epoch: 0, Iteration: 30, loss:7.396928, acc1: 0.000000, acc5:0.000000, throughput: 190.641756 samples/sec
2020/09/23 11:10:40 Train Epoch: 0, Iteration: 40, loss:7.155521, acc1: 0.781250, acc5:0.781250, throughput: 192.405735 samples/sec
2020/09/23 11:10:46 Train Epoch: 0, Iteration: 50, loss:6.938626, acc1: 0.000000, acc5:0.000000, throughput: 186.484859 samples/sec
2020/09/23 11:10:53 Train Epoch: 0, Iteration: 60, loss:6.861095, acc1: 0.781250, acc5:1.562500, throughput: 187.588392 samples/sec
```