### PR TITLE
Close `gocv.Mat`s that we forgot to close

### DIFF
--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -158,10 +158,10 @@ func (p *ImageLoader) collateMiniBatch(inputs []gocv.Mat, labels []int64) miniBa
 	defer func() {
 		// `gocv.Mat`s must be released manually
 		blob.Close()
-		for _, i := inputs {
+		for _, i := range inputs {
 			i.Close()
 		}
-	}
+	}()
 	gocv.BlobFromImages(inputs, &blob, 1.0/255.0, image.Pt(w, h), gocv.NewScalar(0, 0, 0, 0), false, false, gocv.MatTypeCV32F)
 	i := p.trans2.Run(blob).(torch.Tensor)
 	l := torch.NewTensor(labels)

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -155,7 +155,13 @@ func (p *ImageLoader) collateMiniBatch(inputs []gocv.Mat, labels []int64) miniBa
 	w := inputs[0].Cols()
 	h := inputs[0].Rows()
 	blob := gocv.NewMat()
-	defer blob.Close()
+	defer func() {
+		// `gocv.Mat`s must be released manually
+		blob.Close()
+		for _, i := inputs {
+			i.Close()
+		}
+	}
 	gocv.BlobFromImages(inputs, &blob, 1.0/255.0, image.Pt(w, h), gocv.NewScalar(0, 0, 0, 0), false, false, gocv.MatTypeCV32F)
 	i := p.trans2.Run(blob).(torch.Tensor)
 	l := torch.NewTensor(labels)


### PR DESCRIPTION
`gocv.Mat`s must be released manually. They didn't choose `SetFinalizer`, see https://github.com/hybridgroup/gocv/issues/411 for details.