### PR TITLE
Reduce OS threads in ResNet training

### DIFF
--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -124,6 +124,7 @@ func (p *ImageLoader) readSamples() {
 }
 
 func (p *ImageLoader) samplesToMinibatches() {
+	runtime.LockOSThread()
 	inputs := []gocv.Mat{}
 	labels := []int64{}
 	defer func() {
@@ -150,6 +151,7 @@ func (p *ImageLoader) samplesToMinibatches() {
 }
 
 func (p *ImageLoader) collateMiniBatch(inputs []gocv.Mat, labels []int64) miniBatch {
+	runtime.LockOSThread()
 	w := inputs[0].Cols()
 	h := inputs[0].Rows()
 	blob := gocv.NewMat()


### PR DESCRIPTION
Before this PR, the OS threads would be 700+ at 60 iterations and continue to grow.
This PR reduced the OS threads to 190 and stable in the future iterations.
