### PR TITLE
Improve build time

### DIFF
--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -12,8 +12,6 @@ objs := $(srcs:%.cc=%.o)
 	-O -c $< -o $@
 
 libcgotorch.so: $(objs) ${LIBTORCH_DIR}
-	rm -f libtorch
-	ln -s ${LIBTORCH_DIR} libtorch
 	${CXX} 	-L libtorch/lib \
 	$(objs) \
 	-shared \

--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -2,24 +2,26 @@ all : libcgotorch.so
 
 srcs := $(wildcard *.cc)
 hdrs := $(wildcard *.h)
+objs := $(srcs:%.cc=%.o)
 
-libcgotorch.so : $(srcs) $(hdrs) ${LIBTORCH_DIR}
+%.o: %.cc $(hdrs)
+	${CXX} -std=c++14 \
+	-I .. -I libtorch/include \
+	-I libtorch/include/torch/csrc/api/include \
+	-fPIC ${CUDA_FLAGS} \
+	-O -c $< -o $@
+
+libcgotorch.so: $(objs) ${LIBTORCH_DIR}
 	rm -f libtorch
 	ln -s ${LIBTORCH_DIR} libtorch
-	${CXX} -std=c++14 \
-	-I .. \
-	-I libtorch/include \
-	-I libtorch/include/torch/csrc/api/include \
-	-L libtorch/lib \
-	-fPIC \
+	${CXX} 	-L libtorch/lib \
+	$(objs) \
 	-shared \
-	$(srcs) \
-	-O -o $@ ${INSTALL_NAME} \
+	-o $@ ${INSTALL_NAME} \
 	-Wl,-rpath,libtorch/lib \
 	-Wl,-${LOAD} libtorch/lib/libc10.${LIB_SUFFIX} \
 	-lc10 -ltorch -ltorch_cpu \
 	-D_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI} \
-	${CUDA_FLAGS}
 
 clean:
 	rm -rf *.so

--- a/cgotorch/Makefile
+++ b/cgotorch/Makefile
@@ -9,6 +9,7 @@ objs := $(srcs:%.cc=%.o)
 	-I .. -I libtorch/include \
 	-I libtorch/include/torch/csrc/api/include \
 	-fPIC ${CUDA_FLAGS} \
+	-D_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI} \
 	-O -c $< -o $@
 
 libcgotorch.so: $(objs) ${LIBTORCH_DIR}
@@ -18,8 +19,7 @@ libcgotorch.so: $(objs) ${LIBTORCH_DIR}
 	-o $@ ${INSTALL_NAME} \
 	-Wl,-rpath,libtorch/lib \
 	-Wl,-${LOAD} libtorch/lib/libc10.${LIB_SUFFIX} \
-	-lc10 -ltorch -ltorch_cpu \
-	-D_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI} \
+	-lc10 -ltorch -ltorch_cpu
 
 clean:
 	rm -rf *.so

--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -73,6 +73,9 @@ elif [[ "$OS" == "darwin" ]]; then
     fi
 fi
 
+rm -f libtorch
+ln -s ${LIBTORCH_DIR} libtorch
+
 set -o xtrace
 make CXX="$CXX" \
      LIB_SUFFIX="$LIB_SUFFIX" \

--- a/cgotorch/build.sh
+++ b/cgotorch/build.sh
@@ -81,6 +81,5 @@ make CXX="$CXX" \
      GLIBCXX_USE_CXX11_ABI="$GLIBCXX_USE_CXX11_ABI" \
      LOAD="$LOAD" \
      CUDA_FLAGS="$CUDA_FLAGS" \
-     -f Makefile;
-
+     -f Makefile -j
 popd


### PR DESCRIPTION
1. Split the makefile target into multiple targets.
1. Use `make -j` to parallelize the building process.