### PR TITLE
Reduce OS thread number

### DIFF
--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -266,6 +266,10 @@ func decodeImage(buffer []byte, colorSpace string) (gocv.Mat, error) {
 }
 
 func init() {
+	// We use these background threads to call `gocv`. This is because `gocv` makes
+	// `Cgo` calls extensively, if we call `gocv` directly in goroutines(each epoch
+	// creates a new goroutine), the `Cgo` calls will cause Go runtime to create too
+	// many threads.
 	go func() {
 		runtime.LockOSThread()
 		for f := range readSamplesCh {

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -51,8 +51,8 @@ type ImageLoader struct {
 }
 
 var (
-	readSamplesCh          = make(chan func(), 0)
-	samplesToMinibatchesCh = make(chan func(), 0)
+	readSamplesCh          = make(chan func(), 1)
+	samplesToMinibatchesCh = make(chan func(), 1)
 )
 
 // New returns an ImageLoader


### PR DESCRIPTION
Call `gocv` in fixed OS threads to prevent Go runtime from creating too many threads. After this change, the threads number reduced to a quarter of the original version (140+ vs. 600+).