### PR TITLE
fix mnist doc and code

### DIFF
--- a/doc/shuffle_tarball.md
+++ b/doc/shuffle_tarball.md
@@ -20,7 +20,8 @@ allows us to read sequentially from `.tar` or `.tar.gz` file for image files
 without causing frequent mechanical movements in hard drives.
 
 ## Caution
-   gnu-tar should be used on macOS instead of bsdtar.
+
+We must use GNU tar instead of bsdtar on macOS.
 
 ## Shuffling
 

--- a/doc/shuffle_tarball.md
+++ b/doc/shuffle_tarball.md
@@ -19,6 +19,9 @@ file content.  A directory does not have content, but only headers.  This format
 allows us to read sequentially from `.tar` or `.tar.gz` file for image files
 without causing frequent mechanical movements in hard drives.
 
+## Caution
+   gnu-tar should be used on macOS instead of bsdtar.
+
 ## Shuffling
 
 It is critical in deep learning to ensure that each minibatch or consecutive
@@ -68,7 +71,7 @@ divide-and-merge strategy -- `tarball_divide` and `tarball_merge`.
 To install them, we need the Go compiler and run the following commands.
 
 ```bash
-go get github.com/wangkuiyi/gotorch/tools/...
+go get github.com/wangkuiyi/gotorch/tool/...
 ```
 
 We can then find the executable files in `$GOPATH/bin`.

--- a/doc/shuffle_tarball_cn.md
+++ b/doc/shuffle_tarball_cn.md
@@ -13,6 +13,9 @@
 一个描述头部和紧随其后的文件内容。特别地，目录只包含描述部分而没有文件内容。这种结构允许我们以
 顺序方式去读取包含大量图像文件的 `.tar` 或 `.tar.gz` 包，而无需频繁移动磁头去寻找文件。
 
+## 注意
+   在 macOS 上应该使用 gnu-tar 代替 bsdtar
+
 ## 打乱顺序（Shuffling）
 
 在深度学习中，保证输入模型的每一批数据（minibatch）中包含不同的标签是至关重要的。这个特性称为
@@ -53,7 +56,7 @@ drwxr-x---  0 myleott myleott     0 Dec 10  2015 mnist_png/testing/2/
 `tarball_divide` 和 `tarball_merge`。 我们可以通过以下命令来安装它们：
 
 ```bash
-go get github.com/wangkuiyi/gotorch/tools/...
+go get github.com/wangkuiyi/gotorch/tool/...
 ```
 
 运行上述命令后，我们可以在 `$GOPATH/bin` 中找到这两个工具的二进制文件。
@@ -105,6 +108,7 @@ go get github.com/wangkuiyi/gotorch/tools/...
    rm [0-9].tar.gz
    tarball_divide mnist_png_testing.tar.gz
    tarball_merge -out=mnist_png_testing_shuffled.tar.gz [0-9].tar.gz
+   rm [0-9].tar.gz
    tar tvf mnist_png_testing_shuffled.tar.gz | grep \.png$ | wc -l
    tar tvf mnist_png_testing.tar.gz | grep \.png$ | wc -l
    ```

--- a/doc/shuffle_tarball_cn.md
+++ b/doc/shuffle_tarball_cn.md
@@ -14,7 +14,8 @@
 顺序方式去读取包含大量图像文件的 `.tar` 或 `.tar.gz` 包，而无需频繁移动磁头去寻找文件。
 
 ## 注意
-   在 macOS 上应该使用 gnu-tar 代替 bsdtar
+
+在 macOS 上应该使用 gnu-tar 代替 bsdtar。
 
 ## 打乱顺序（Shuffling）
 

--- a/example/mnist/mnist.go
+++ b/example/mnist/mnist.go
@@ -4,7 +4,6 @@ import (
 	"encoding/gob"
 	"flag"
 	"fmt"
-	"image"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/wangkuiyi/gotorch/vision/imageloader"
 	"github.com/wangkuiyi/gotorch/vision/models"
 	"github.com/wangkuiyi/gotorch/vision/transforms"
+	"gocv.io/x/gocv"
 )
 
 var device torch.Device
@@ -169,17 +169,7 @@ func loadModel(modelFn string) *models.MLPModule {
 }
 
 func predictFile(fn string, m *models.MLPModule) {
-	f, e := os.Open(fn)
-	if e != nil {
-		log.Fatal(e)
-	}
-	defer f.Close()
-
-	img, _, e := image.Decode(f)
-	if e != nil {
-		log.Fatalf("Cannot decode input image: %v", e)
-	}
-
+	img := gocv.IMRead(fn, gocv.IMReadGrayScale)
 	t := transforms.ToTensor().Run(img)
 	n := transforms.Normalize([]float32{0.1307}, []float32{0.3081}).Run(t)
 	fmt.Println(m.Forward(n).Argmax().Item())


### PR DESCRIPTION
fix some doc and use `gocv` to load image instead of `image` per #323 

before:
```
mnist ➤ go run . predict mnist_png/testing/1/385.png                                                                                                      git:develop*
2020/10/25 20:53:33 No CUDA found; CPU only
panic: ToTensorTransformer can not transform the input type: *image.Gray

goroutine 1 [running, locked to thread]:
github.com/wangkuiyi/gotorch/vision/transforms.ToTensorTransformer.Run(0x41b4d20, 0xc00002b980, 0x41ffa20)
        /Users/qiu/go/src/github.com/wangkuiyi/gotorch/vision/transforms/to_tensor.go:68 +0x557
main.predictFile(0x7ffeefbff482, 0x1b, 0xc00002b940)
        /Users/qiu/go/src/github.com/wangkuiyi/gotorch/example/mnist/mnist.go:183 +0x1a6
main.predict(0x41c988f, 0x14, 0xc0000121d0, 0x1, 0x1)
        /Users/qiu/go/src/github.com/wangkuiyi/gotorch/example/mnist/mnist.go:148 +0x1c5
main.main()
        /Users/qiu/go/src/github.com/wangkuiyi/gotorch/example/mnist/mnist.go:55 +0x50c
exit status 2
```
after:
```
mnist ➤ go run . predict mnist_png/testing/1/385.png                                                                                                      git:develop*
2020/10/25 20:56:11 No CUDA found; CPU only
1
```