### PR TITLE
add image-record-gen cmd

### DIFF
--- a/cmd/image-recordio-gen/main.go
+++ b/cmd/image-recordio-gen/main.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/wangkuiyi/recordio"
+)
+
+var dataset = flag.String("dataset", "", "path to dataset directory")
+var label = flag.String("label", "", "path to label txt file")
+var output = flag.String("output", "", "output record files directory")
+var shuffle = flag.Bool("shuffle", true, "shuffle dataset")
+var recordsPerShard = flag.Int("recordsPerShard", 4096, "maximum number of records per shard file")
+
+type imageRecord struct {
+	Image []byte
+	Label int
+}
+
+func loadImage(fname string, vocab map[string]int) (*imageRecord, error) {
+	b, err := ioutil.ReadFile(fname)
+	if err != nil {
+		return nil, err
+	}
+	classStr := filepath.Base(filepath.Dir(fname))
+	ir := &imageRecord{
+		Image: b,
+		Label: vocab[classStr],
+	}
+	return ir, nil
+}
+
+func encode(ir *imageRecord) ([]byte, error) {
+	buf := &bytes.Buffer{}
+	err := gob.NewEncoder(buf).Encode(*ir)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func buildLabelVocabulary(label string) (map[string]int, error) {
+	file, err := os.Open(label)
+	if err != nil {
+		return nil, nil
+	}
+	defer file.Close()
+
+	vocab := map[string]int{}
+	scanner := bufio.NewScanner(file)
+	idx := 0
+	for scanner.Scan() {
+		vocab[strings.TrimSpace(scanner.Text())] = idx
+		idx++
+	}
+	return vocab, nil
+}
+
+func create(p string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(p), 0770); err != nil {
+		return nil, err
+	}
+	return os.Create(p)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func main() {
+	flag.Parse()
+	vocab, err := buildLabelVocabulary(*label)
+	if err != nil {
+		panic(err)
+	}
+
+	files, err := filepath.Glob(*dataset + "/*/*.*")
+	if *shuffle {
+		rand.Seed(time.Now().UnixNano())
+		rand.Shuffle(len(files), func(i, j int) { files[i], files[j] = files[j], files[i] })
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	start := []int{}
+	end := []int{}
+	for i := 0; i < len(files); i += *recordsPerShard {
+		start = append(start, i)
+		end = append(end, min(i+*recordsPerShard, len(files)))
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(start))
+
+	for i := 0; i < len(start); i++ {
+		go func(i int) {
+			s := start[i]
+			e := end[i]
+			f, _ := create(fmt.Sprintf("%s/data-%05d", *output, i))
+			w := recordio.NewWriter(f, -1, -1)
+			for row := s; row < e; row++ {
+				ir, _ := loadImage(files[row], vocab)
+				b, _ := encode(ir)
+				w.Write(b)
+			}
+			w.Close()
+			f.Close()
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/wangkuiyi/gotorch
 go 1.13
 
 require (
+	github.com/golang/snappy v0.0.2 // indirect
 	github.com/stretchr/testify v1.6.1
+	github.com/wangkuiyi/recordio v0.0.7
 	github.com/x448/float16 v0.8.4
 	gocv.io/x/gocv v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
+github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/wangkuiyi/recordio v0.0.7 h1:RJqvZwEJASQEOYatBXM18jIPqvX8jaaRRi5FIU8TzdA=
+github.com/wangkuiyi/recordio v0.0.7/go.mod h1:F9BSVEi3PBGLpyIjZi+hvv5qtUFMvn6vSIZ+kklmhHg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 gocv.io/x/gocv v0.24.0 h1:xtm5AnFNUtFvSmU+R/CgX7FguL7EDGEubhDdviX2rPY=

--- a/vision/imageloader/imageloader.go
+++ b/vision/imageloader/imageloader.go
@@ -25,12 +25,6 @@ type miniBatch struct {
 	label torch.Tensor
 }
 
-// RGB color
-const RGB string = "rgb"
-
-// GRAY color
-const GRAY string = "gray"
-
 // ImageLoader struct
 type ImageLoader struct {
 	r          *tgz.Reader
@@ -278,15 +272,13 @@ func splitComposeByToTensor(compose *transforms.ComposeTransformer) (*transforms
 func decodeImage(buffer []byte, colorSpace string) (gocv.Mat, error) {
 	var m gocv.Mat
 	var e error
-	if colorSpace == RGB {
+	if colorSpace == "rgb" {
 		m, e = gocv.IMDecode(buffer, gocv.IMReadColor)
-	} else if colorSpace == GRAY {
+		gocv.CvtColor(m, &m, gocv.ColorBGRToRGB)
+	} else if colorSpace == "gray" {
 		m, e = gocv.IMDecode(buffer, gocv.IMReadGrayScale)
 	} else {
 		return m, fmt.Errorf("Cannot read image with color space %v", colorSpace)
-	}
-	if colorSpace == RGB {
-		gocv.CvtColor(m, &m, gocv.ColorBGRToRGB)
 	}
 	return m, e
 }


### PR DESCRIPTION
The `image-recordio-gen` command converts an image folder with label txt to recordio file format.

Let's take mnist dataset as an example. We could download the dataset from https://github.com/myleott/mnist_png.git.

The dataset contains two directories: training and testing. We need to make a label file. The label file maps a class string to an int index. Following is the label file for mnist dataset.

```log
0
1
2
3
4
5
6
7
8
9
```

Then, we could run the `image-recordio-gen` command:

```bash
$GOPATH/bin/image-recordio-gen -label=$MNIST/label.txt -dataset=$MNIST/training -output=$MNIST/train_record -recordsPerShard=8192
```
We could find the recordio shard files in `train_record` directory:

```bash
data-00000
data-00001
data-00002
data-00003
data-00004
data-00005
data-00006
data-00007
```